### PR TITLE
fix linux path uri

### DIFF
--- a/server/src/uri.lua
+++ b/server/src/uri.lua
@@ -1,4 +1,5 @@
 local fs = require 'bee.filesystem'
+local platform = require 'bee.platform'
 
 local function decode(uri)
     -- Unix-like系统根是/
@@ -9,6 +10,12 @@ local function decode(uri)
         log.error('uri decode failed: ', uri)
         return nil
     end
+
+    -- linux uri example: file:///home/user/project/
+    if platform.OS == 'Linux' then
+        return fs.path(uri:sub(8))
+    end
+   
     local names = {}
     for name in uri:sub(9):gmatch '[^%/]+' do
         names[#names+1] = name:gsub('%%([0-9a-fA-F][0-9a-fA-F])', function (hex)


### PR DESCRIPTION
这修复了Linux下不能正确写 .vscode/settings.json 的问题. 
原因: linux 下的uri 输入参数是 file:///home/user/project/ 这样(3个斜杠, 包括代表root 的第三个/ ), 而不是 file://// (4个斜杠). 在linux 下用浏览器打开本地文件也是这个形式.
现在linux 下写入.vscode/settings.json 没问题了, 但.vscode/settings.json 更新后(例如更新Lua.diagnostics.globals ),  Problem 下面的警告列表没有马上更新(windows 版本可以). 如果你大概知道会是什么地方的问题, 请提示一下. 谢谢. - John 