### PR TITLE
fix run on macOS

### DIFF
--- a/osx.sh
+++ b/osx.sh
@@ -16,7 +16,7 @@ cd -
 ./3rd/luamake/luamake
 
 cd server
-mv bin/*.so .
+cp bin/*.so .
 
 # avoid too many file opened error
 ulimit -n 4000


### PR DESCRIPTION
fix an issue on macOS.
```
  publish (master) ✔ /Users/jiya/workspace/lua-language-server/publish/0.9.8/server/bin/lua-language-server /Users/jiya/workspace/lua-language-server/publish/0.9.8/server/main.lua                                                                           (master|) ✔
/Users/jiya/workspace/lua-language-server/publish/0.9.8/server/bin/lua-language-server: ...kspace/lua-language-server/publish/0.9.8/server/main.lua:8: module 'bee.filesystem' not found:
	no field package.preload['bee.filesystem']
	no file '/Users/jiya/workspace/lua-language-server/publish/0.9.8/server/src/bee/filesystem.lua'
	no file '/Users/jiya/workspace/lua-language-server/publish/0.9.8/server/src/bee/filesystem/init.lua'
	no file '/Users/jiya/workspace/lua-language-server/publish/0.9.8/server/bin/bee/filesystem.dll'
	no file '/Users/jiya/workspace/lua-language-server/publish/0.9.8/server/bin/bee/filesystem.so'
	no file '/Users/jiya/workspace/lua-language-server/publish/0.9.8/server/bin/bee.dll'
	no file '/Users/jiya/workspace/lua-language-server/publish/0.9.8/server/bin/bee.so'
stack traceback:
	[C]: in function 'require'
	...kspace/lua-language-server/publish/0.9.8/server/main.lua:8: in main chunk
	[C]: in ?
```