### PR TITLE
Add completionProvider to server capabilities

### DIFF
--- a/script/method/initialize.lua
+++ b/script/method/initialize.lua
@@ -11,6 +11,9 @@ return function (lsp)
     lsp._inited = true
     return {
         capabilities = {
+            completionProvider = {
+                triggerCharacters = { '.' },
+            },
             hoverProvider = true,
             definitionProvider = true,
             referencesProvider = true,


### PR DESCRIPTION
Some language server clients like vim-lsp[1] check capabilities more
strictly before enabling them. In this case a missing completionProvider
item in the server capabilities caused completion to not work at all.

[1] https://github.com/prabirshrestha/vim-lsp