### PR TITLE
Create first workspace based on client's rootUri

### DIFF
--- a/script/method/initialize.lua
+++ b/script/method/initialize.lua
@@ -1,3 +1,5 @@
+local workspace = require 'workspace'
+
 local function allWords()
     local str = [[abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.:('"[,#*@| ]]
     local list = {}
@@ -7,8 +9,14 @@ local function allWords()
     return list
 end
 
-return function (lsp)
+return function (lsp, params)
     lsp._inited = true
+
+    if params.rootUri then
+        lsp.workspace = workspace(lsp, 'root')
+        lsp.workspace:init(params.rootUri)
+    end
+
     return {
         capabilities = {
             completionProvider = {


### PR DESCRIPTION
Currently the server will send a workspace/workspaceFolders request and
use the first folder that is reported as workspace root.  This doesn't
work with clients that don't support workspaceFolders capability.

The rootUri field of the response to 'initialize' is mandatory and can
be used to create the initial workspace too.  This patch does exactly
this.