### PR TITLE
搜索引用时添加"检查 generic 穿透的情况"

### DIFF
--- a/test/references/init.lua
+++ b/test/references/init.lua
@@ -302,3 +302,60 @@ TEST [[
 ---@return <?any?>
 function f() end
 ]]
+
+TEST [[
+---@class Dog
+local Dog = {}
+function Dog:<?eat?>()
+end
+
+---@generic T
+---@param type1 T
+---@return T
+function foobar(type1)
+    return {}
+end
+
+local v1 = foobar(Dog)
+v1:<!eat!>()
+]]
+
+TEST [[
+---@class Dog
+local Dog = {}
+function Dog:<?eat?>()
+end
+
+---@class Master
+local Master = {}
+
+---@generic T
+---@param type1 string
+---@param type2 T
+---@return T
+function Master:foobar(type1, type2)
+    return {}
+end
+
+local v1 = Master:foobar("", Dog)
+v1.<!eat!>()
+]]
+
+--[=[ TODO
+TEST [[
+---@class Dog
+local Dog = {}
+function Dog:<?eat?>()
+end
+
+---@generic T
+---@param type1 T
+---@return string, T
+function foobar(type1)
+    return "", {}
+end
+
+local v1, v2 = foobar(Dog)
+v2:<!eat!>()
+]]
+]=]


### PR DESCRIPTION
目前只是实现基本的检查 generic，有个 TODO 测试用例还没有实现，需先弄明白下面这个疑问。

@sumneko 请教下 local a, b = func() 的ast里，怎么找到 b 了。一路顺着 func() 往上找，只找到 a。