### PR TITLE
可以通过选项 diagnostics.disable 来禁用语法错误

### DIFF
--- a/script/provider/diagnostic.lua
+++ b/script/provider/diagnostic.lua
@@ -141,7 +141,9 @@ function m.syntaxErrors(uri, ast)
     local results = {}
 
     for _, err in ipairs(ast.errs) do
-        results[#results+1] = buildSyntaxError(uri, err)
+        if not config.config.diagnostics.disable[err.type:lower():gsub('_', '-')] then
+            results[#results+1] = buildSyntaxError(uri, err)
+        end
     end
 
     return results


### PR DESCRIPTION
改后，PROBLEMS 中出现的问题均可禁用