### PR TITLE
处理luadoc在某些情况绑定错误的情况

### DIFF
--- a/script/parser/guide.lua
+++ b/script/parser/guide.lua
@@ -588,20 +588,21 @@ end
 ---@param lines table
 ---@return integer {name = 'row'}
 ---@return integer {name = 'col'}
+---@return table {name = 'line'} 命中那一行的细节信息
 function m.positionOf(lines, offset)
     if offset < 1 then
-        return 0, 0
+        return 0, 0, nil
     end
     local lastLine = lines[#lines]
     if offset > lastLine.finish then
-        return #lines, lastLine.finish - lastLine.start + 1
+        return #lines, lastLine.finish - lastLine.start + 1, lastLine
     end
     local min = 1
     local max = #lines
     for _ = 1, 100 do
         if max <= min then
             local line = lines[min]
-            return min, offset - line.start + 1
+            return min, offset - line.start + 1, line
         end
         local row = (max - min) // 2 + min
         local line = lines[row]
@@ -610,7 +611,7 @@ function m.positionOf(lines, offset)
         elseif offset > line.finish then
             min = row + 1
         else
-            return row, offset - line.start + 1
+            return row, offset - line.start + 1, line
         end
     end
     error('Stack overflow!')

--- a/script/parser/guide.lua
+++ b/script/parser/guide.lua
@@ -588,21 +588,20 @@ end
 ---@param lines table
 ---@return integer {name = 'row'}
 ---@return integer {name = 'col'}
----@return table {name = 'line'} 命中那一行的细节信息
 function m.positionOf(lines, offset)
     if offset < 1 then
-        return 0, 0, nil
+        return 0, 0
     end
     local lastLine = lines[#lines]
     if offset > lastLine.finish then
-        return #lines, lastLine.finish - lastLine.start + 1, lastLine
+        return #lines, lastLine.finish - lastLine.start + 1
     end
     local min = 1
     local max = #lines
     for _ = 1, 100 do
         if max <= min then
             local line = lines[min]
-            return min, offset - line.start + 1, line
+            return min, offset - line.start + 1
         end
         local row = (max - min) // 2 + min
         local line = lines[row]
@@ -611,7 +610,7 @@ function m.positionOf(lines, offset)
         elseif offset > line.finish then
             min = row + 1
         else
-            return row, offset - line.start + 1, line
+            return row, offset - line.start + 1
         end
     end
     error('Stack overflow!')
@@ -663,6 +662,10 @@ function m.lineRange(lines, row, ignoreNL)
     else
         return line.start, line.finish
     end
+end
+
+function m.lineData(lines, row)
+    return lines[row]
 end
 
 function m.getKeyTypeOfLiteral(obj)

--- a/script/parser/luadoc.lua
+++ b/script/parser/luadoc.lua
@@ -917,8 +917,9 @@ local function isNextLine(lns, binded, doc)
         return false
     end
     local lastDoc = binded[#binded]
-    local _, lastDocStartCol, lastDocStartLine = guide.positionOf(lns, lastDoc.originalComment.start)
-    if haveCodeBeforeDocInCurLine(lastDocStartLine, lastDocStartCol) then
+    local lastDocStartRow, lastDocStartCol = guide.positionOf(lns, lastDoc.originalComment.start)
+    local lastDocStartLineData = guide.lineData(lns, lastDocStartRow)
+    if haveCodeBeforeDocInCurLine(lastDocStartLineData, lastDocStartCol) then
         return false
     end
 

--- a/script/parser/luadoc.lua
+++ b/script/parser/luadoc.lua
@@ -907,11 +907,21 @@ local function buildLuaDoc(comment)
     return result
 end
 
+---当前行在注释doc前是否有代码
+local function haveCodeBeforeDocInCurLine(lineData, docStartCol)
+    return docStartCol > lineData.sp + lineData.tab + 3
+end
+
 local function isNextLine(lns, binded, doc)
     if not binded then
         return false
     end
     local lastDoc = binded[#binded]
+    local _, lastDocStartCol, lastDocStartLine = guide.positionOf(lns, lastDoc.originalComment.start)
+    if haveCodeBeforeDocInCurLine(lastDocStartLine, lastDocStartCol) then
+        return false
+    end
+
     local lastRow = guide.positionOf(lns, lastDoc.finish)
     local newRow  = guide.positionOf(lns, doc.start)
     return newRow - lastRow == 1
@@ -1034,6 +1044,7 @@ return function (_, state)
             if ast.finish < doc.finish then
                 ast.finish = doc.finish
             end
+            doc.originalComment = comment
         end
     end
 

--- a/test/definition/luadoc.lua
+++ b/test/definition/luadoc.lua
@@ -169,3 +169,31 @@ end
 
 AAAA.a.<?SSDF?>
 ]]
+
+TEST [[
+---@class Cat
+local <!m!> ---hahaha
+---@class Dog
+local 	m2
+---@type Cat
+local <?<!v!>?>
+]]
+
+TEST [[
+---@class Cat
+local <!m!> --hahaha
+---@class Dog
+local 	m2
+---@type Cat
+local <?<!v!>?>
+]]
+
+TEST [[
+---@class Cat
+ local <!m!> ---hahaha
+
+  ---@class Dog
+   local 	m2
+	 ---@type Cat
+	 	 local <?<!v!>?>
+]]


### PR DESCRIPTION
目前版本，下面用例会报错。
```
TEST [[
---@class Cat
local <!m!> ---hahaha
---@class Dog
local 	m2
---@type Cat
local <?<!v!>?>
]]
```
因为`---@class Cat`、`---@class Dog` 都绑定到 m2。m 上没有任何绑定。

本 PR 已修复该问题。