### PR TITLE
非治本方式处理"在拥有类继承关系的变量值上，诊断undefined field可能误报"

### DIFF
--- a/script/parser/guide.lua
+++ b/script/parser/guide.lua
@@ -1771,7 +1771,7 @@ function m.searchSameFieldsCrossMethod(status, ref, start, queue)
     local newMarkMethod = mark['method']
     local methodStatus = m.status(status)
     m.searchRefs(methodStatus, method, 'ref')
-    if not oldMarkMethod and newMarkMethod then
+    if (not oldMarkMethod) and newMarkMethod and (next(methodStatus.results) == nil) then
         methodStatus.results[#methodStatus.results + 1] = method
     end
     for _, md in ipairs(methodStatus.results) do

--- a/script/parser/guide.lua
+++ b/script/parser/guide.lua
@@ -1762,13 +1762,18 @@ function m.searchSameFieldsCrossMethod(status, ref, start, queue)
         mark = {}
         status.crossMethodMark = mark
     end
+    local oldMarkMethod = mark['method']
     local method = m.searchSameMethod(ref, mark)
                 or m.searchSameMethodCrossSelf(ref, mark)
     if not method then
         return
     end
+    local newMarkMethod = mark['method']
     local methodStatus = m.status(status)
     m.searchRefs(methodStatus, method, 'ref')
+    if not oldMarkMethod and newMarkMethod then
+        methodStatus.results[#methodStatus.results + 1] = method
+    end
     for _, md in ipairs(methodStatus.results) do
         queue[#queue+1] = {
             obj   = md,

--- a/test/diagnostics/init.lua
+++ b/test/diagnostics/init.lua
@@ -945,3 +945,21 @@ v2 = v
 v2:method1()
 v2:method2() -- 这个感觉实际应该报错更合适
 ]]
+
+TEST [[
+---@class Foo
+Foo = {}
+function Foo:Constructor()
+    self.bar1 = 1
+end
+
+---@class Foo2: Foo
+local Foo2 = {}
+function Foo2:Constructor()
+    self.bar2 = 1
+end
+
+---@type Foo2
+local v
+print(v.bar1)
+]]


### PR DESCRIPTION
同时也会处理自动补全可能不全的问题。

这个只是治标不治本的方法，后续如果有治本方法可以去除它。

#318 相关的问题