### PR TITLE
 添加对 EmmyLua table type 的支持

### DIFF
--- a/script/parser/compile.lua
+++ b/script/parser/compile.lua
@@ -12,6 +12,8 @@ local specials = {
     ['loadfile']     = true,
     ['pcall']        = true,
     ['xpcall']       = true,
+    ['pairs']        = true,
+    ['ipairs']       = true,
 }
 
 _ENV = nil

--- a/script/parser/guide.lua
+++ b/script/parser/guide.lua
@@ -2206,8 +2206,8 @@ local function getTableAndIndexIfIsForPairsKeyOrValue(ref)
     end
     local pairsCallObj = rootCallObj.node
 
-    if not pairsCallObj.node or pairsCallObj.node.type ~= 'getglobal'
-        or (pairsCallObj.node[1] ~= 'pairs' and pairsCallObj.node[1] ~= 'ipairs') then
+    if not pairsCallObj.node
+        or (pairsCallObj.node.special ~= 'pairs' and pairsCallObj.node.special ~= 'ipairs') then
         return
     end
 

--- a/script/parser/luadoc.lua
+++ b/script/parser/luadoc.lua
@@ -260,30 +260,36 @@ local function parseTypeUnitArray(node)
     return result
 end
 
-local function parseTypeUnitGeneric(node)
+local function parseTypeUnitTable(parent, node)
     if not checkToken('symbol', '<', 1) then
         return nil
     end
     if not nextSymbolOrError('<') then
         return nil
     end
-    local key = parseType(node)
+
+    local result = {
+        type   = 'doc.type.table',
+        start  = node.start,
+        node   = node,
+        parent = parent,
+    }
+
+    local key = parseType(result)
     if not key or not nextSymbolOrError(',') then
         return nil
     end
-    local value = parseType(node)
+    local value = parseType(result)
     if not value then
         return nil
     end
     nextSymbolOrError('>')
-    local result = {
-        type   = 'doc.type.generic',
-        start  = node.start,
-        finish = getFinish(),
-        node   = node,
-        key    = key,
-        value  = value,
-    }
+    
+    node.parent = result;
+    result.finish = getFinish()
+    result.key = key
+    result.value = value
+
     return result
 end
 
@@ -397,7 +403,7 @@ local function parseTypeUnit(parent, content)
     result.parent = parent
     while true do
         local newResult = parseTypeUnitArray(result)
-                    or    parseTypeUnitGeneric(result)
+                    or    parseTypeUnitTable(parent, result)
         if not newResult then
             break
         end

--- a/script/vm/getDocs.lua
+++ b/script/vm/getDocs.lua
@@ -16,6 +16,11 @@ local function getTypesOfFile(uri)
         or src.type == 'doc.class.name'
         or src.type == 'doc.extends.name'
         or src.type == 'doc.alias.name' then
+            if src.type == 'doc.type.name' then
+                if guide.getParentDocTypeTable(src) then
+                    return
+                end
+            end
             local name = src[1]
             if name then
                 if not types[name] then

--- a/test/definition/luadoc.lua
+++ b/test/definition/luadoc.lua
@@ -263,3 +263,57 @@ function Foo:<!bar1!>() end
 local v1
 print(v1[1].<?bar1?>)
 ]]
+
+TEST [[
+---@class Foo
+local Foo = {}
+function Foo:<!bar1!>() end
+
+---@class Foo2
+local Foo2 = {}
+function Foo2:bar1() end
+
+---@type Foo2<number, Foo>
+local v1
+print(v1[1].<?bar1?>)
+]]
+
+--TODO 得扩展 simple 的信息才能识别这种情况了
+--TEST [[
+-----@class Foo
+--local Foo = {}
+--function Foo:bar1() end
+--
+-----@class Foo2
+--local Foo2 = {}
+--function Foo2:<!bar1!>() end
+--
+-----@type Foo2<number, Foo>
+--local v1
+--print(v1.<?bar1?>)
+--]]
+
+TEST [[
+---@class Foo
+local Foo = {}
+function Foo:<!bar1!>() end
+
+---@type table<number, Foo>
+local v1
+for i, v in ipairs(v1) do
+    print(v.<?bar1?>)
+end
+]]
+
+TEST [[
+---@class Foo
+local Foo = {}
+function Foo:<!bar1!>() end
+
+---@type table<Foo, Foo>
+local v1
+for k, v in pairs(v1) do
+    print(k.<?bar1?>)
+    print(v.bar1)
+end
+]]

--- a/test/definition/luadoc.lua
+++ b/test/definition/luadoc.lua
@@ -300,6 +300,7 @@ function Foo:<!bar1!>() end
 
 ---@type table<number, Foo>
 local v1
+local ipairs = ipairs
 for i, v in ipairs(v1) do
     print(v.<?bar1?>)
 end

--- a/test/definition/luadoc.lua
+++ b/test/definition/luadoc.lua
@@ -253,3 +253,13 @@ function Generic(arg1) print(arg1) end
 local v1 = Generic("Foo")
 print(v1.<?bar1?>)
 ]]
+
+TEST [[
+---@class Foo
+local Foo = {}
+function Foo:<!bar1!>() end
+
+---@type table<number, Foo>
+local v1
+print(v1[1].<?bar1?>)
+]]

--- a/test/definition/luadoc.lua
+++ b/test/definition/luadoc.lua
@@ -317,3 +317,16 @@ for k, v in pairs(v1) do
     print(v.bar1)
 end
 ]]
+
+TEST [[
+---@class Foo
+local Foo = {}
+function Foo:<!bar1!>() end
+
+---@type table<number, table<number, Foo>>
+local v1
+for i, v in ipairs(v1) do
+    local v2 = v[1]
+    print(v2.<?bar1?>)
+end
+]]

--- a/test/definition/luadoc.lua
+++ b/test/definition/luadoc.lua
@@ -331,3 +331,13 @@ for i, v in ipairs(v1) do
     print(v2.<?bar1?>)
 end
 ]]
+
+TEST [[
+---@class Foo
+local Foo = {}
+function Foo:<!bar1!>() end
+
+---@type table<number, table<number, Foo>>
+local v1
+print(v1[1][1].<?bar1?>)
+]]

--- a/test/example/guide.txt
+++ b/test/example/guide.txt
@@ -2702,7 +2702,7 @@ function m.viewInferType(infers)
         or src.type == 'doc.class.name'
         or src.type == 'doc.type.name'
         or src.type == 'doc.type.array'
-        or src.type == 'doc.type.generic' then
+        or src.type == 'doc.type.table' then
             if infer.type ~= 'any' then
                 hasDoc = true
                 break
@@ -2717,7 +2717,7 @@ function m.viewInferType(infers)
             or src.type == 'doc.class.name'
             or src.type == 'doc.type.name'
             or src.type == 'doc.type.array'
-            or src.type == 'doc.type.generic'
+            or src.type == 'doc.type.table'
             or src.type == 'doc.type.enum'
             or src.type == 'doc.resume' then
                 local tp = infer.type or 'any'
@@ -2946,7 +2946,7 @@ local function getDocTypeUnitName(status, unit)
         typeName = 'function'
     elseif unit.type == 'doc.type.array' then
         typeName = getDocTypeUnitName(status, unit.node) .. '[]'
-    elseif unit.type == 'doc.type.generic' then
+    elseif unit.type == 'doc.type.table' then
         typeName = ('%s<%s, %s>'):format(
             getDocTypeUnitName(status, unit.node),
             m.viewInferType(m.getDocTypeNames(status, unit.key)),

--- a/test/hover/init.lua
+++ b/test/hover/init.lua
@@ -1171,7 +1171,7 @@ TEST [[
 local <?x?>
 ]]
 [[
-local x: table<ClassA, ClassB> {}
+local x: table<ClassA, ClassB>
 ]]
 
 --TEST [[

--- a/test/hover/init.lua
+++ b/test/hover/init.lua
@@ -1171,7 +1171,7 @@ TEST [[
 local <?x?>
 ]]
 [[
-local x: table<ClassA, ClassB>
+local x: table<ClassA, ClassB> {}
 ]]
 
 --TEST [[


### PR DESCRIPTION
相关讨论见 #331

还有个用例需要扩充 simple 信息才能放开
```lua
--TODO 得扩展 simple 的信息才能识别这种情况了
TEST [[
---@class Foo
local Foo = {}
function Foo:bar1() end

---@class Foo2
local Foo2 = {}
function Foo2:<!bar1!>() end

---@type Foo2<number, Foo>
local v1
print(v1.<?bar1?>)
]]
```