### PR TITLE
[main.lua] fix empty rootPath cause try "/log" folder

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1,6 +1,7 @@
 local currentPath = debug.getinfo(1, 'S').source:sub(2)
 local rootPath = currentPath:gsub('[/\\]*[^/\\]-$', '')
-loadfile((rootPath == '' and '.' or rootPath) .. '/platform.lua')('script')
+rootPath = (rootPath == '' and '.' or rootPath)
+loadfile(rootPath .. '/platform.lua')('script')
 local fs = require 'bee.filesystem'
 
 local function expanduser(path)


### PR DESCRIPTION
When run follow command with get error message, 
```
$ bin/Linux/lua-language-server  -E main.lua
bin/Linux/lua-language-server: filesystem error: cannot create directories: Permission denied [/log]
```
Which is caused by empty `ROOT` and the folder path for log with be `/log` in follow line,
https://github.com/sumneko/lua-language-server/blob/1458139721646236406825a03a21152d98753515/main.lua#L40

This change try to assign a default value `"."` for `rootPath` to fix the error.