### PR TITLE
perf: searchSameFields: return early when obj was already locked

### DIFF
--- a/script/core/guide.lua
+++ b/script/core/guide.lua
@@ -3016,7 +3016,7 @@ function m.searchSameFields(status, simple, mode)
             locks[start] = lock
         end
         if lock[obj] then
-            return
+            return false
         end
         lock[obj] = true
         queueLen = queueLen + 1
@@ -3032,13 +3032,17 @@ function m.searchSameFields(status, simple, mode)
                 forces[queueLen] = force
             end
         end
+        return true
     end
     local function pushQueue(obj, start, force)
         if obj.type == 'getlocal'
         or obj.type == 'setlocal' then
             obj = obj.node
         end
-        appendQueue(obj, start, force)
+        if appendQueue(obj, start, force) == false then
+            -- no need to process the rest if obj is already locked
+            return
+        end
         if obj.type == 'local' and obj.ref then
             for _, ref in ipairs(obj.ref) do
                 appendQueue(ref, start, force)


### PR DESCRIPTION
The changes by 41ed018e80df12b59cdd0e60cce7484b0c972d81 no longer stopped processing when the main object was already locked. This PR fixes that.

Fixes #496