### PR TITLE
"workspace/semanticTokens/refresh" should be a request

### DIFF
--- a/script/provider/semantic-tokens.lua
+++ b/script/provider/semantic-tokens.lua
@@ -103,7 +103,7 @@ end
 
 local function refresh()
     log.debug('Refresh semantic tokens.')
-    proto.notify('workspace/semanticTokens/refresh', json.null)
+    proto.request('workspace/semanticTokens/refresh', json.null)
 end
 
 config.watch(function (key, value)


### PR DESCRIPTION
Hi @sumneko ,
The "workspace/semanticTokens/refresh" should be a request according the spec (https://microsoft.github.io/language-server-protocol/specifications/specification-3-17/#semanticTokens_refreshRequest).
This change try to correct it and be tested in my local with lsp-mode.
Please help review and merge this change. 
Thanks