### PR TITLE
Change comment in redundant-return

### DIFF
--- a/script/core/diagnostics/redundant-return.lua
+++ b/script/core/diagnostics/redundant-return.lua
@@ -3,7 +3,7 @@ local guide   = require 'parser.guide'
 local lang    = require 'language'
 local define  = require 'proto.define'
 
--- reports 'return' or 'return nil' at the end of functions
+-- reports 'return' without any return values at the end of functions
 return function (uri, callback)
     local ast = files.getState(uri)
     if not ast then


### PR DESCRIPTION
A small change to the comment in redundant-return to reflect what it is actually doing.