### PR TITLE
fix settings wiki link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Please [help me][en-US] improve the quality of `en-US`.
 ## Setting
 
 * In VSCode: Just use the setting of VSCode.
-* Standalone: See https://github.com/sumneko/lua-language-server/wiki/Setting-without-VSCode
+* Standalone: See https://github.com/sumneko/lua-language-server/wiki/Setting
 
 ## Credit
 


### PR DESCRIPTION
The file seems to [have been renamed](https://github.com/sumneko/lua-language-server/wiki/_compare/5a805c2193ab9c0a7e8f99a33a50c42cdb507bf6) so it currently leads to creating a new page.