### PR TITLE
fix(semantic-tokens): `data` field can't be nil

### DIFF
--- a/script/core/semantic-tokens.lua
+++ b/script/core/semantic-tokens.lua
@@ -849,7 +849,7 @@ return function (uri, start, finish)
     end
 
     if #results == 0 then
-        return nil
+        return {}
     end
 
     results = solveMultilineAndOverlapping(state, results)


### PR DESCRIPTION
`textDocument/semanticTokens/range` should return `SemanticTokens | null` from LSP specification.

`data` field of the `SemanticTokens` must be a array, even if no result.