### PR TITLE
Fix regular expression to find root directory in make/bootstrap.lua

### DIFF
--- a/make/bootstrap.lua
+++ b/make/bootstrap.lua
@@ -48,7 +48,7 @@ local root; do
         if sep == '\\' then
             sep = '/\\'
         end
-        local pattern = "["..sep.."][^"..sep.."]+"
+        local pattern = "["..sep.."]+[^"..sep.."]+"
         root = package.cpath:match("([^;]+)"..pattern..pattern.."$")
         arg[0] = root .. package.config:sub(1,1) .. 'main.lua'
     end


### PR DESCRIPTION
If there is a posix path like `/a/b//c`, the regex pattern to find root directory won't match anything and cause server crashing even if the path is valid. I think windows path also has this problem.

This will happen if someone  add an environment path end with a separator.

```bash
export PATH="$PATH:/path/to/lua-language-server/bin/"
```

This environment path will be used to extend to `package.cpath`. So, `package.cpath` here is `/path/to/lua-language-server/bin//?.so` which the current regex pattern can't recognize.