### PR TITLE
Ensure that a completion result has 'isIncomplete'

### DIFF
--- a/script/provider/provider.lua
+++ b/script/provider/provider.lua
@@ -618,6 +618,9 @@ m.register 'textDocument/completion' {
             end
             items[i] = item
         end
+        if result.incomplete == nil then
+            result.incomplete = false
+        end
         return {
             isIncomplete = result.incomplete,
             items        = items,


### PR DESCRIPTION
Any key in the table of a returned response that has a value of 'nil' will be
excluded from the response's result, and so it needs to be set to
'false'.

In other words, for a textDocument/completion response to include 'isIncomplete' in the result, the table returned in `m.register 'textDocument/complete'` must have `isIncomplete` set to `false`. If it is set to `nil`, then it will be excluded from the response.

`isIncomplete` is a required required parameter in a 'textDocument/completion' response (https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionList).