### PR TITLE
fix(semantic-tokens): coreect token type priority

### DIFF
--- a/script/core/semantic-tokens.lua
+++ b/script/core/semantic-tokens.lua
@@ -161,17 +161,7 @@ local Care = util.switch()
             }
             return
         end
-        -- 5. References to other functions
-        if infer.hasType(loc, 'function') then
-            results[#results+1] = {
-                start      = source.start,
-                finish     = source.finish,
-                type       = define.TokenTypes['function'],
-                modifieres = source.type == 'setlocal' and define.TokenModifiers.declaration or nil,
-            }
-            return
-        end
-        -- 6. Class declaration
+        -- 5. Class declaration
             -- only search this local
         if loc.bindDocs then
             for i, doc in ipairs(loc.bindDocs) do
@@ -189,7 +179,17 @@ local Care = util.switch()
                 end
             end
         end
-        -- 6. const 变量 | Const variable
+        -- 6. References to other functions
+        if infer.hasType(loc, 'function') then
+            results[#results+1] = {
+                start      = source.start,
+                finish     = source.finish,
+                type       = define.TokenTypes['function'],
+                modifieres = source.type == 'setlocal' and define.TokenModifiers.declaration or nil,
+            }
+            return
+        end
+        -- 7. const 变量 | Const variable
         if loc.attrs then
             for _, attr in ipairs(loc.attrs) do
                 local name = attr[1]


### PR DESCRIPTION
If metatable with `__call` method, adding `@class` and `@type fun()`
together for a class make the token be regarded as function, we should
make sure `@class` override `@type`.


![image](https://user-images.githubusercontent.com/17562139/161388881-90bbb04e-914f-431b-ba90-204e8de2a58a.png)


->

![image](https://user-images.githubusercontent.com/17562139/161388916-3e85cb04-a2a0-40c9-8038-2cafa7db965b.png)
