### PR TITLE
Event emitter support fix

### DIFF
--- a/script/core/completion/completion.lua
+++ b/script/core/completion/completion.lua
@@ -1401,7 +1401,7 @@ local function getCallEnumsAndFuncs(source, index, oop, call)
                 and doc.field[1] == source[1] then
                     local eventName = noder.getFieldEventName(doc)
                     if eventName and eventName == myEventName then
-                        local docFunc = doc.extends.types[1].args[2].extends.types[1]
+                        local docFunc = doc.extends.types[1].args[index].extends.types[1]
                         results[#results+1] = {
                             label       = infer.viewDocFunction(docFunc),
                             description = doc.comment,

--- a/script/core/completion/completion.lua
+++ b/script/core/completion/completion.lua
@@ -1396,11 +1396,11 @@ local function getCallEnumsAndFuncs(source, index, oop, call)
                 local eventName = noder.getFieldEventName(doc)
                 if eventName then
                     if     indexType == 1 then
-                            results[#results+1] = {
-                                label       = ('%q'):format(eventName),
-                                description = doc.comment,
-                                kind        = define.CompletionItemKind.EnumMember,
-                            }
+                        results[#results+1] = {
+                            label       = ('%q'):format(eventName),
+                            description = doc.comment,
+                            kind        = define.CompletionItemKind.EnumMember,
+                        }
                     elseif indexType == 2 then
                         if eventName == valueBeforeIndex then
                             local docFunc = doc.extends.types[1].args[index].extends.types[1]

--- a/script/core/noder.lua
+++ b/script/core/noder.lua
@@ -887,7 +887,8 @@ local function compileCallParam(noders, call, sourceID)
     local eventNodeID
     for firstIndex, callArg in ipairs(call.args) do
         firstIndex = firstIndex - fixIndex
-        if firstIndex == 1 and callArg.type == 'string' then
+        if  (firstIndex == 1 or firstIndex == 2)
+        and callArg.type == 'string' then
             if callArg[1] then
                 eventNodeID = sformat('%s%s%s'
                     , nodeID

--- a/script/core/noder.lua
+++ b/script/core/noder.lua
@@ -140,11 +140,7 @@ local function getMethodNode(source)
     end
 end
 
-local function getFieldEventName(field)
-    if field._eventName then
-        return field._eventName or nil
-    end
-    field._eventName = false
+local function getFieldArgs(field)
     local fieldType = field.extends
     if not fieldType then
         return nil
@@ -153,19 +149,29 @@ local function getFieldEventName(field)
     if not docFunc or docFunc.type ~= 'doc.type.function' then
         return nil
     end
-    local firstArg = docFunc.args and docFunc.args[1]
+    return docFunc.args
+end
+
+local function getFieldEventName(field)
+    if field._eventName then
+        return field._eventName or nil
+    end
+    field._eventName = false
+
+    local args = getFieldArgs(field)
+    local firstArg = args and args[1]
     if not firstArg then
         return nil
     end
     local secondArg
     if firstArg.name[1] == 'self' then
-        firstArg = docFunc.args[2]
+        firstArg = args[2]
         if not firstArg then
             return nil
         end
-        secondArg = docFunc.args[3]
+        secondArg = args[3]
     else
-        secondArg = docFunc.args[2]
+        secondArg = args[2]
     end
     if not secondArg then
         return
@@ -1685,6 +1691,7 @@ function m.eachID(noders)
     return next, noders.source
 end
 
+m.getFieldArgs = getFieldArgs
 m.getFieldEventName = getFieldEventName
 
 ---获取对象的noders

--- a/test/completion/common.lua
+++ b/test/completion/common.lua
@@ -2682,6 +2682,22 @@ emit:on('won', <??>)
 }
 
 TEST [[
+--- @class Emit
+--- @field on fun(self: Emit, eventName: string, cb: function)
+--- @field on fun(self: Emit, eventName: '"died"', cb: fun(i: integer))
+--- @field on fun(self: Emit, eventName: '"won"', cb: fun(s: string))
+local emit = {}
+
+emit.on(emit, 'won', <??>)
+]]
+{
+    [1] = {
+        label    = 'fun(s: string)',
+        kind     = define.CompletionItemKind.Function,
+    }
+}
+
+TEST [[
 local function f()
     local inferCache
     in<??>

--- a/test/completion/common.lua
+++ b/test/completion/common.lua
@@ -2640,9 +2640,9 @@ class2:<??>
 
 TEST [[
 --- @class Emit
---- @field on fun(eventName: string, cb: function)
---- @field on fun(eventName: '"died"', cb: fun(i: integer))
---- @field on fun(eventName: '"won"', cb: fun(s: string))
+--- @field on fun(self: Emit, eventName: string, cb: function)
+--- @field on fun(self: Emit, eventName: '"died"', cb: fun(i: integer))
+--- @field on fun(self: Emit, eventName: '"won"', cb: fun(s: string))
 local emit = {}
 
 emit:on('<??>')
@@ -2654,6 +2654,22 @@ TEST [[
 --- @field on fun(eventName: string, cb: function)
 --- @field on fun(eventName: '"died"', cb: fun(i: integer))
 --- @field on fun(eventName: '"won"', cb: fun(s: string))
+local emit = {}
+
+emit.on('died', <??>)
+]]
+{
+    [1] = {
+        label    = 'fun(i: integer)',
+        kind     = define.CompletionItemKind.Function,
+    }
+}
+
+TEST [[
+--- @class Emit
+--- @field on fun(self: Emit, eventName: string, cb: function)
+--- @field on fun(self: Emit, eventName: '"died"', cb: fun(i: integer))
+--- @field on fun(self: Emit, eventName: '"won"', cb: fun(s: string))
 local emit = {}
 
 emit:on('won', <??>)

--- a/test/type_inference/init.lua
+++ b/test/type_inference/init.lua
@@ -941,6 +941,17 @@ emit:on("died", function (<?i?>)
 end)
 ]]
 
+TEST 'integer' [[
+--- @class Emit
+--- @field on fun(self: Emit, eventName: string, cb: function)
+--- @field on fun(self: Emit, eventName: '"died"', cb: fun(i: integer))
+--- @field on fun(self: Emit, eventName: '"won"', cb: fun(s: string))
+local emit = {}
+
+emit.on(self, "died", function (<?i?>)
+end)
+]]
+
 TEST '👍' [[
 ---@class 👍
 local <?x?>


### PR DESCRIPTION
After the fix for #809 landed, Luadoc functions needed to specify the `self` argument if it were meant to be used as an OOP method.

This PR updates the event emitter spec to support `self` and fixes a few crashes / completion issues, such as:

```lua
--- @class EmitFail
--- @field on fun(self, eventName: string, cb: function)
--- @field on fun(self, eventName: '"died"', cb: fun(i: integer))
--- @field on fun(self, eventName: '"won"', cb: fun(s: string))
local emit = {}
emit:on("died", --[[ completion here crashes ]])
emit.on("died", --[[ completion here crashes ]])
```

Before, wrong position for completion:
![image](https://user-images.githubusercontent.com/79615454/161398098-67ffcc36-be72-420e-8619-f66e1b4665eb.png)

After fix:
![image](https://user-images.githubusercontent.com/79615454/161398143-54bdf1f7-31d5-45a4-91d9-e2ed278a46a3.png)

_(Edit)_ I am not familiar with the code architecture, do let me know if there should be any changes !