### PR TITLE
feat(completion): truncate arguments for callSnippet

### DIFF
--- a/script/core/completion/completion.lua
+++ b/script/core/completion/completion.lua
@@ -157,15 +157,26 @@ local function buildFunctionSnip(source, value, oop)
     local name = (getName(source) or ''):gsub('^.+[$.:]', '')
     local args = getArg(value, oop)
     local id = 0
+    local needTruncateId = 0
     args = args:gsub('[^,]+', function (arg)
-        if arg:match('^%s+[^?]+%?:') or arg:match('^%s+%.%.%.:') then
-            return ''
-        end
         id = id + 1
+        if arg:match('^%s*[^?]+%?:') or arg:match('^%s*%.%.%.:') then
+            if needTruncateId == 0 then
+                needTruncateId = id
+            end
+        else
+            needTruncateId = 0
+        end
         return arg:gsub('^(%s*)(.+)', function (sp, word)
             return ('%s${%d:%s}'):format(sp, id, word)
         end)
-    end):gsub(',+$', '')
+    end)
+    if needTruncateId > 0 then
+        local start = args:find(',?%s*%${' .. needTruncateId)
+        if start then
+            args = start == 1 and '$1' or args:sub(1, start - 1)
+        end
+    end
     return ('%s(%s)'):format(name, args)
 end
 

--- a/script/core/completion/completion.lua
+++ b/script/core/completion/completion.lua
@@ -158,11 +158,14 @@ local function buildFunctionSnip(source, value, oop)
     local args = getArg(value, oop)
     local id = 0
     args = args:gsub('[^,]+', function (arg)
+        if arg:match('^%s+[^?]+%?:') or arg:match('^%s+%.%.%.:') then
+            return ''
+        end
         id = id + 1
         return arg:gsub('^(%s*)(.+)', function (sp, word)
             return ('%s${%d:%s}'):format(sp, id, word)
         end)
-    end)
+    end):gsub(',+$', '')
     return ('%s(%s)'):format(name, args)
 end
 

--- a/test/completion/common.lua
+++ b/test/completion/common.lua
@@ -2373,6 +2373,90 @@ zzzz<??>
         insertText = 'zzzz(${1:a: any}, ${2:b: any})',
     },
 }
+
+TEST [[
+---@param a any
+---@param b? any
+---@param c? any
+---@vararg any
+local function foo(a, b, c, ...) end
+foo<??>
+]]
+{
+    {
+        label = 'foo(a, b, c, ...)',
+        kind  = define.CompletionItemKind.Function,
+        insertText = 'foo',
+    },
+    {
+        label = 'foo(a, b, c, ...)',
+        kind  = define.CompletionItemKind.Snippet,
+        insertText = 'foo(${1:a: any})',
+    },
+}
+
+TEST [[
+---@param a any
+---@param b? any
+---@param c? any
+---@vararg any
+local function foo(a, b, c, ...) end
+foo<??>
+]]
+{
+    {
+        label = 'foo(a, b, c, ...)',
+        kind  = define.CompletionItemKind.Function,
+        insertText = 'foo',
+    },
+    {
+        label = 'foo(a, b, c, ...)',
+        kind  = define.CompletionItemKind.Snippet,
+        insertText = 'foo(${1:a: any})',
+    },
+}
+
+TEST [[
+---@param a? any
+---@param b? any
+---@param c? any
+---@vararg any
+local function foo(a, b, c, ...) end
+foo<??>
+]]
+{
+    {
+        label = 'foo(a, b, c, ...)',
+        kind  = define.CompletionItemKind.Function,
+        insertText = 'foo',
+    },
+    {
+        label = 'foo(a, b, c, ...)',
+        kind  = define.CompletionItemKind.Snippet,
+        insertText = 'foo($1)',
+    },
+}
+
+TEST [[
+---@param a? any
+---@param b any
+---@param c? any
+---@vararg any
+local function foo(a, b, c, ...) end
+foo<??>
+]]
+{
+    {
+        label = 'foo(a, b, c, ...)',
+        kind  = define.CompletionItemKind.Function,
+        insertText = 'foo',
+    },
+    {
+        label = 'foo(a, b, c, ...)',
+        kind  = define.CompletionItemKind.Snippet,
+        insertText = 'foo(${1:a?: any}, ${2:b: any})',
+    },
+}
 Cared['insertText'] = false
 
 TEST [[


### PR DESCRIPTION
The callSnippet always expands all the optional arguments and variable
argument that is annoying.
To truncate optional arguments and variable arguments help users more
frequently use `callSnippet`. We already have the label and signature to get
the total arguments.

This behavior is like tsserver.