### PR TITLE
fix(completion): avoid unnecessary file sep as trigger chars

### DIFF
--- a/script/provider/completion.lua
+++ b/script/provider/completion.lua
@@ -7,7 +7,7 @@ local ws     = require 'workspace'
 local isEnable = false
 
 local function allWords()
-    local str = '\t\n.:(\'"[,#*@|=-{/\\ +?'
+    local str = '\t\n.:(\'"[,#*@|=-{ +?'
     local mark = {}
     local list = {}
     for c in str:gmatch '.' do
@@ -19,6 +19,11 @@ local function allWords()
         if postfix ~= '' and not mark[postfix] then
             list[#list+1] = postfix
             mark[postfix] = true
+        end
+        local separator = config.get(scp.uri, 'Lua.completion.requireSeparator')
+        if not mark[separator] then
+            list[#list+1] = separator
+            mark[separator] = true
         end
     end
     return list


### PR DESCRIPTION
Language clients such as coc.nvim have multiple completion sources that
may contain a file path completion source triggered by `/` or `\`.
However, if users use the default requireSeparator `.` setting under
lua-language-server, type `/` or `\` in a string will fire a lot of unless
items whose priority is high than file path items and make file path
items at the bottom of candidates.