### PR TITLE
fix(client): reuse the previous keys for config

### DIFF
--- a/script/client.lua
+++ b/script/client.lua
@@ -211,7 +211,13 @@ local function applyConfig(cfg, uri, changes)
     for _, change in ipairs(changes) do
         if scp:isChildUri(change.uri)
         or scp:isLinkedUri(change.uri) then
-            cfg[change.key] = config.getRaw(change.uri, change.key)
+            local value = config.getRaw(change.uri, change.key)
+            local key = change.key:match('^Lua%.(.+)$')
+            if cfg[key] then
+                cfg[key] = value
+            else
+                cfg[change.key] = value
+            end
             ok = true
         end
     end


### PR DESCRIPTION
In .luarc, we use key without `Lua.` prefix which is good for completion through schema.