### PR TITLE
perf(diagnostic): avoid first send

### DIFF
--- a/script/provider/diagnostic.lua
+++ b/script/provider/diagnostic.lua
@@ -256,12 +256,12 @@ function m.doDiagnostic(uri, isScopeDiag)
         end
     end
 
+    pushResult()
+
     -- always re-sent diagnostics of current file
     if not isScopeDiag then
         m.cache[uri] = nil
     end
-
-    pushResult()
 
     local lastPushClock = time.time()
     ---@async


### PR DESCRIPTION
If the cache is equal to the full result, we should avoid to notify
client during first stage.