### PR TITLE
StringUtil.cpp in EmmyLuaCodeStyle requires wildcards lib

### DIFF
--- a/make/code_format.lua
+++ b/make/code_format.lua
@@ -7,7 +7,8 @@ lm:source_set 'code_format' {
     rootdir = '../3rd/EmmyLuaCodeStyle',
     includes = {
         "include",
-        "../bee.lua/3rd/lua"
+        "../bee.lua/3rd/lua",
+        "3rd/wildcards/include"
     },
     sources = {
         -- codeFormatLib


### PR DESCRIPTION
Note: This happens on my machine, but not in CI, I did not look into why, but this fixes local compilation.

Ubuntu 21.04
gcc (Ubuntu 10.3.0-1ubuntu1) 10.3.0

Fix for:
```
[59/82] Compile C++ build/obj/code_format/StringUtil.obj
FAILED: build/obj/code_format/StringUtil.obj
gcc -MMD -MT build/obj/code_format/StringUtil.obj -MF build/obj/code_format/StringUtil.obj.d -std=c++17 -O2 -Wall -fvisibility=hidden -I3rd/EmmyLuaCodeStyle/include -I3rd/bee.lua/3rd/lua -DNDEBUG -Wall -Werror -o build/obj/code_format/StringUtil.obj -c 3rd/EmmyLuaCodeStyle/Util/src/StringUtil.cpp
3rd/EmmyLuaCodeStyle/Util/src/StringUtil.cpp:5:10: fatal error: wildcards/match.hpp: No such file or directory
    5 | #include "wildcards/match.hpp"
      |          ^~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```

Closes https://github.com/sumneko/lua-language-server/issues/1128