### PR TITLE
Alternate fix for #1173

### DIFF
--- a/tools/love-api.lua
+++ b/tools/love-api.lua
@@ -156,7 +156,7 @@ local function buildFunction(func, node, typeName)
     for _, param in ipairs(func.variants[1].arguments or {}) do
         for paramName in param.name:gmatch '[%a_][%w_]*' do
             params[#params+1] = paramName
-			local optional = param.type == 'table' and isTableOptional(param.table) or param.default
+			local optional = param.type == 'table' and isTableOptional(param.table) or (param.default ~= nil)
             text[#text+1] = ('---@param %s%s %s # %s'):format(
                 paramName,
                 optional and '?' or '',

--- a/tools/love-api.lua
+++ b/tools/love-api.lua
@@ -50,6 +50,16 @@ local function formatIndex(key)
     return ('[%q]'):format(key)
 end
 
+local function isTableOptional(tbl)
+	local optional = true
+	for _, field in ipairs(tbl) do
+		if field.default == nil then
+			optional = nil
+		end
+	end
+	return optional
+end
+
 local buildType
 
 local function buildDocTable(tbl)
@@ -146,6 +156,9 @@ local function buildFunction(func, node, typeName)
     for _, param in ipairs(func.variants[1].arguments or {}) do
         for paramName in param.name:gmatch '[%a_][%w_]*' do
             params[#params+1] = paramName
+			if param.type == 'table' then
+				param.default = isTableOptional(param.table)
+			end
             text[#text+1] = ('---@param %s%s %s # %s'):format(
                 paramName,
                 param.default == nil and '' or '?',

--- a/tools/love-api.lua
+++ b/tools/love-api.lua
@@ -156,12 +156,9 @@ local function buildFunction(func, node, typeName)
     for _, param in ipairs(func.variants[1].arguments or {}) do
         for paramName in param.name:gmatch '[%a_][%w_]*' do
             params[#params+1] = paramName
-			if param.type == 'table' then
-				param.default = isTableOptional(param.table)
-			end
             text[#text+1] = ('---@param %s%s %s # %s'):format(
                 paramName,
-                param.default == nil and '' or '?',
+                (param.type == 'table' and isTableOptional(param.table) or param.default) == nil and '' or '?',
                 buildType(param),
                 param.description
             )

--- a/tools/love-api.lua
+++ b/tools/love-api.lua
@@ -156,9 +156,10 @@ local function buildFunction(func, node, typeName)
     for _, param in ipairs(func.variants[1].arguments or {}) do
         for paramName in param.name:gmatch '[%a_][%w_]*' do
             params[#params+1] = paramName
+			local optional = (param.type == 'table' and isTableOptional(param.table) or param.default)
             text[#text+1] = ('---@param %s%s %s # %s'):format(
                 paramName,
-                (param.type == 'table' and isTableOptional(param.table) or param.default) == nil and '' or '?',
+                optional and '?' or '',
                 buildType(param),
                 param.description
             )

--- a/tools/love-api.lua
+++ b/tools/love-api.lua
@@ -156,7 +156,7 @@ local function buildFunction(func, node, typeName)
     for _, param in ipairs(func.variants[1].arguments or {}) do
         for paramName in param.name:gmatch '[%a_][%w_]*' do
             params[#params+1] = paramName
-			local optional = (param.type == 'table' and isTableOptional(param.table) or param.default)
+			local optional = param.type == 'table' and isTableOptional(param.table) or param.default
             text[#text+1] = ('---@param %s%s %s # %s'):format(
                 paramName,
                 optional and '?' or '',


### PR DESCRIPTION
Since the annotation files for LOVE API are built automatically, I updated the builder. If an argument is of table type its default field is always nil. I added a function that iterates over all the fields in the argument's table field and checks whether all of them have a default value. If so, I assign default = true to the argument. That should make the builder add the needed '?' next to the parameter name in the generated meta file.

See the love-api project's [graphics module](https://github.com/love2d-community/love-api/blob/69e7e015698c0834798a0b9ffeb3a98786b60f1d/modules/graphics/Graphics.lua#L2167-L2188).