### PR TITLE
Add optional flag (?) to overloads in `love2d` and `lovr` builders

### DIFF
--- a/tools/love-api.lua
+++ b/tools/love-api.lua
@@ -124,10 +124,11 @@ local function buildDocFunc(variant, overload)
         if param.name == '...' then
             params[#params+1] = '...'
         else
+			local optional = (param.type == 'table' and isTableOptional(param.table) or (param.default ~= nil)) and '?' or ''
             if param.name:find '^[\'"]' then
-                params[#params+1] = ('%s: %s|%q'):format(param.name:sub(2, -2), getTypeName(param.type), param.name)
+                params[#params+1] = ('%s%s: %s|%q'):format(param.name:sub(2, -2), optional, getTypeName(param.type), param.name)
             else
-                params[#params+1] = ('%s: %s'):format(param.name, getTypeName(param.type))
+                params[#params+1] = ('%s%s: %s'):format(param.name, optional, getTypeName(param.type))
             end
         end
     end

--- a/tools/love-api.lua
+++ b/tools/love-api.lua
@@ -50,17 +50,20 @@ local function formatIndex(key)
     return ('[%q]'):format(key)
 end
 
-local function isTableOptional(tbl)
-    if not tbl then
-        return false
-    end
-    local optional = true
-    for _, field in ipairs(tbl) do
-        if field.default == nil then
-            optional = nil
-        end
-    end
-    return optional
+local function getOptional(param)
+	if param.type == 'table' then
+		if not param.table then
+			return ''
+		end
+		for _, field in ipairs(param.table) do
+			if field.default == nil then
+				return ''
+			end
+		end
+		return '?'
+	else
+		return (param.default ~= nil) and '?' or ''
+	end
 end
 
 local buildType
@@ -124,11 +127,10 @@ local function buildDocFunc(variant, overload)
         if param.name == '...' then
             params[#params+1] = '...'
         else
-			local optional = (param.type == 'table' and isTableOptional(param.table) or (param.default ~= nil)) and '?' or ''
             if param.name:find '^[\'"]' then
-                params[#params+1] = ('%s%s: %s|%q'):format(param.name:sub(2, -2), optional, getTypeName(param.type), param.name)
+                params[#params+1] = ('%s%s: %s|%q'):format(param.name:sub(2, -2), getOptional(param), getTypeName(param.type), param.name)
             else
-                params[#params+1] = ('%s%s: %s'):format(param.name, optional, getTypeName(param.type))
+                params[#params+1] = ('%s%s: %s'):format(param.name, getOptional(param), getTypeName(param.type))
             end
         end
     end
@@ -160,10 +162,9 @@ local function buildFunction(func, node, typeName)
     for _, param in ipairs(func.variants[1].arguments or {}) do
         for paramName in param.name:gmatch '[%a_][%w_]*' do
             params[#params+1] = paramName
-            local optional = param.type == 'table' and isTableOptional(param.table) or (param.default ~= nil)
             text[#text+1] = ('---@param %s%s %s # %s'):format(
                 paramName,
-                optional and '?' or '',
+                getOptional(param),
                 buildType(param),
                 param.description
             )

--- a/tools/lovr-api.lua
+++ b/tools/lovr-api.lua
@@ -128,10 +128,11 @@ local function buildDocFunc(variant, overload)
         if param.name == '...' then
             params[#params+1] = '...'
         else
+			local optional = (param.type == 'table' and isTableOptional(param.table) or (param.default ~= nil)) and '?' or ''
             if param.name:find '^[\'"]' then
-                params[#params+1] = ('%s: %s|%q'):format(param.name:sub(2, -2), getTypeName(param.type), param.name)
+                params[#params+1] = ('%s%s: %s|%q'):format(param.name:sub(2, -2), optional, getTypeName(param.type), param.name)
             else
-                params[#params+1] = ('%s: %s'):format(param.name, getTypeName(param.type))
+                params[#params+1] = ('%s%s: %s'):format(param.name, optional, getTypeName(param.type))
             end
         end
     end

--- a/tools/lovr-api.lua
+++ b/tools/lovr-api.lua
@@ -51,17 +51,20 @@ local function formatIndex(key)
     return ('[%q]'):format(key)
 end
 
-local function isTableOptional(tbl)
-    if not tbl then
-        return false
-    end
-    local optional = true
-    for _, field in ipairs(tbl) do
-        if field.default == nil then
-            optional = nil
-        end
-    end
-    return optional
+local function getOptional(param)
+	if param.type == 'table' then
+		if not param.table then
+			return ''
+		end
+		for _, field in ipairs(param.table) do
+			if field.default == nil then
+				return ''
+			end
+		end
+		return '?'
+	else
+		return (param.default ~= nil) and '?' or ''
+	end
 end
 
 local buildType
@@ -128,11 +131,10 @@ local function buildDocFunc(variant, overload)
         if param.name == '...' then
             params[#params+1] = '...'
         else
-			local optional = (param.type == 'table' and isTableOptional(param.table) or (param.default ~= nil)) and '?' or ''
             if param.name:find '^[\'"]' then
-                params[#params+1] = ('%s%s: %s|%q'):format(param.name:sub(2, -2), optional, getTypeName(param.type), param.name)
+                params[#params+1] = ('%s%s: %s|%q'):format(param.name:sub(2, -2), getOptional(param), getTypeName(param.type), param.name)
             else
-                params[#params+1] = ('%s%s: %s'):format(param.name, optional, getTypeName(param.type))
+                params[#params+1] = ('%s%s: %s'):format(param.name, getOptional(param), getTypeName(param.type))
             end
         end
     end
@@ -164,10 +166,9 @@ local function buildFunction(func, typeName)
     for _, param in ipairs(func.variants[1].arguments or {}) do
         for paramName in param.name:gmatch '[%a_][%w_]*' do
             params[#params+1] = paramName
-            local optional = param.type == 'table' and isTableOptional(param.table) or (param.default ~= nil)
             text[#text+1] = ('---@param %s%s %s # %s'):format(
                 paramName,
-                optional and '?' or '',
+                getOptional(param),
                 buildType(param),
                 param.description
             )


### PR DESCRIPTION
Summary of changes:
- Made builders add `?` next to argument names if the argument has a default value. 
- `isTableOptional` refactored to `getOptional` that returns `'?'` or an empty string if based on whether the argument is or is not optional. Ready to be inserted in a string with `string.format`. 

The second change is a separate commit and can be reverted if not desired.