### PR TITLE
繁體中文翻譯

### DIFF
--- a/locale/zh-tw/meta.lua
+++ b/locale/zh-tw/meta.lua
@@ -1,10 +1,10 @@
 ---@diagnostic disable: undefined-global, lowercase-global
 
 arg                 =
-'獨立版Lua的啟動參數。'
+'獨立版Lua的啟動引數。'
 
 assert              =
-'如果其參數 `v` 的值為假（`nil` 或 `false`）， 它就呼叫 $error； 否則，回傳所有的參數。 在錯誤情況時， `message` 指那個錯誤對象； 如果不提供這個參數，參數預設為 `"assertion failed!"` 。'
+'如果其引數 `v` 的值為假（ `nil` 或 `false` ），它就呼叫 $error ；否則，回傳所有的引數。在錯誤情況時， `message` 指那個錯誤對象；如果不提供這個引數，預設為 `"assertion failed!"` 。'
 
 cgopt.collect       =
 '做一次完整的垃圾回收循環。'
@@ -28,34 +28,34 @@ cgopt.isrunning     =
 '回傳表示回收器是否在工作的布林值。'
 
 collectgarbage      =
-'這個函式是垃圾回收器的通用介面。 透過參數 opt 它提供了一組不同的功能。'
+'這個函式是垃圾回收器的一般介面。透過引數 opt 它提供了一組不同的功能。'
 
 dofile              =
-'打開該名字的檔案，並執行檔案中的 Lua 程式碼區塊。 不帶參數呼叫時， `dofile` 執行標準輸入的內容（`stdin`）。 回傳該程式碼區塊的所有回傳值。 對於有錯誤的情況，`dofile` 將錯誤反饋給呼叫者 （即，`dofile` 沒有執行在保護模式下）。'
+'打開該名字的檔案，並執行檔案中的 Lua 程式碼區塊。不帶引數呼叫時， `dofile` 執行標準輸入的內容（`stdin` ）。回傳該程式碼區塊的所有回傳值。對於有錯誤的情況， `dofile` 將錯誤回饋給呼叫者（即 `dofile` 沒有執行在保護模式下）。'
 
 error               =
 [[
-中止上一次保護函式呼叫， 將錯誤對象 `message` 回傳。 函式 `error` 永遠不會回傳。
+中止上一次保護函式呼叫，將錯誤對象 `message` 回傳。函式 `error` 永遠不會回傳。
 
-當 `message` 是一個字串時，通常 `error` 會把一些有關出錯位置的資訊附加在資訊的前頭。 level 參數指明了怎樣獲得出錯位置。
+當 `message` 是一個字串時，通常 `error` 會把一些有關出錯位置的資訊附加在訊息的前頭。 `level` 引數指明了怎樣獲得出錯位置。
 ]]
 
 _G                  =
-'一個全域變數（非函式）， 內部儲存有全域環境（參見 §2.2）。 Lua 自己不使用這個變數； 改變這個變數的值不會對任何環境造成影響，反之亦然。'
+'一個全域變數（非函式），內部儲存有全域環境（參見 §2.2）。 Lua 自己不使用這個變數；改變這個變數的值不會對任何環境造成影響，反之亦然。'
 
 getfenv             =
-'回傳給定函式的環境。`f` 可以是一個Lua函式，也可是一個表示呼叫堆疊層級的數字。'
+'回傳給定函式的環境。 `f` 可以是一個Lua函式，也可是一個表示呼叫堆疊層級的數字。'
 
 getmetatable        =
-'如果 `object` 不包含元表，回傳 `nil` 。 否則，如果在該對象的元表中有 `"__metatable"` 域時回傳其關聯值， 沒有時回傳該對象的元表。'
+'如果 `object` 不包含元表，回傳 `nil` 。否則，如果在該物件的元表中有 `"__metatable"` 域時回傳其關聯值，沒有時回傳該對象的元表。'
 
 ipairs              =
 [[
-回傳三個值（疊代函式、表 `t` 以及 `0` ）， 如此，以下程式碼
+回傳三個值（疊代函式、表 `t` 以及 `0` ），如此，以下程式碼
 ```lua
     for i,v in ipairs(t) do body end
 ```
-將疊代鍵值對 `（1,t[1]) ，(2,t[2])， ...` ，直到第一個空值。
+將疊代鍵值對 `(1,t[1])、(2,t[2])...` ，直到第一個空值。
 ]]
 
 loadmode.b        =
@@ -66,12 +66,12 @@ loadmode.bt       =
 '可以是二進制也可以是文字。'
 
 load['<5.1']      =
-'使用 `func` 分段載入程式碼區塊。 每次呼叫 `func` 必須回傳一個字串用於連接前文。'
+'使用 `func` 分段載入程式碼區塊。每次呼叫 `func` 必須回傳一個字串用於連接前文。'
 load['>5.2']      =
 [[
 載入一個程式碼區塊。
 
-如果 `chunk` 是一個字串，程式碼區塊指這個字串。 如果 `chunk` 是一個函式， `load` 不斷地呼叫它獲取程式碼區塊的片段。 每次對 `chunk` 的呼叫都必須回傳一個字串緊緊連接在上次呼叫的回傳串之後。 當回傳空串、`nil`、或是不回傳值時，都表示程式碼區塊結束。
+如果 `chunk` 是一個字串，程式碼區塊指這個字串。如果 `chunk` 是一個函式， `load` 不斷地呼叫它獲取程式碼區塊的片段。每次對 `chunk` 的呼叫都必須回傳一個字串緊緊連接在上次呼叫的回傳串之後。當回傳空串、 `nil` 、或是不回傳值時，都表示程式碼區塊結束。
 ]]
 
 loadfile            =
@@ -81,22 +81,22 @@ loadstring          =
 '使用給定字串載入程式碼區塊。'
 
 module              =
-'新增一個模組。'
+'建立一個模組。'
 
 next                =
 [[
-執行程式來走訪表中的所有域。 第一個參數是要走訪的表，第二個參數是表中的某個鍵。 `next` 回傳該鍵的下一個鍵及其關聯的值。 如果用 `nil` 作為第二個參數呼叫 `next` 將回傳初始鍵及其關聯值。 當以最後一個鍵去呼叫，或是以 `nil` 呼叫一張空表時， `next` 回傳 `nil`。 如果不提供第二個參數，將預設它就是 `nil`。 特別指出，你可以用 `next(t)` 來判斷一張表是否是空的。
+執行程式來走訪表中的所有域。第一個引數是要走訪的表，第二個引數是表中的某個鍵。 `next` 回傳該鍵的下一個鍵及其關聯的值。如果用 `nil` 作為第二個引數呼叫 `next` 將回傳初始鍵及其關聯值。當以最後一個鍵去呼叫，或是以 `nil` 呼叫一張空表時， `next` 回傳 `nil`。如果不提供第二個引數，將預設它就是 `nil`。特別指出，你可以用 `next(t)` 來判斷一張表是否是空的。
 
-索引在走訪過程中的順序無定義， 即使是數字索引也是這樣。 （如果想按數字順序走訪表，可以使用數字形式的 `for` 。）
+索引在走訪過程中的順序無定義，即使是數字索引也是這樣。（如果想按數字順序走訪表，可以使用數字形式的 `for` 。）
 
-當在走訪過程中你給表中並不存在的域賦值， `next` 的行為是未定義的。 然而你可以去修改那些已存在的域。 特別指出，你可以清除一些已存在的域。
+當在走訪過程中你給表中並不存在的域賦值， `next` 的行為是未定義的。然而你可以去修改那些已存在的域。特別指出，你可以清除一些已存在的域。
 ]]
 
 pairs               =
 [[
-如果 `t` 有元方法 `__pairs`， 以 `t` 為參數呼叫它，並回傳其回傳的前三個值。
+如果 `t` 有元方法 `__pairs` ，以 `t` 為引數呼叫它，並回傳其回傳的前三個值。
 
-否則，回傳三個值：`next` 函式， 表 `t`，以及 `nil`。 因此以下程式碼
+否則，回傳三個值： `next` 函式，表 `t` ，以及 `nil` 。因此以下程式碼
 ```lua
     for k,v in pairs(t) do body end
 ```
@@ -106,69 +106,69 @@ pairs               =
 ]]
 
 pcall               =
-'傳入參數，以 *保護模式* 呼叫函式 `f` 。 這意味著 `f` 中的任何錯誤不會拋出； 取而代之的是，`pcall` 會將錯誤捕獲到，並回傳一個狀態碼。 第一個回傳值是狀態碼（一個布林值）， 當沒有錯誤時，其為真。 此時，`pcall` 同樣會在狀態碼後回傳所有呼叫的結果。 在有錯誤時，`pcall` 回傳 `false` 加錯誤訊息。'
+'透過將函式 `f` 傳入引數，以 *保護模式* 呼叫 `f` 。這意味著 `f` 中的任何錯誤不會擲回；取而代之的是， `pcall` 會將錯誤捕獲到，並回傳一個狀態碼。第一個回傳值是狀態碼（一個布林值），當沒有錯誤時，其為 `true` 。此時， `pcall` 同樣會在狀態碼後回傳所有呼叫的結果。在有錯誤時，`pcall` 回傳 `false` 加錯誤訊息。'
 
 print               =
-'接收任意數量的參數，並將它們的值列印到 `stdout`。 它用 `tostring` 函式將每個參數都轉換為字串。 `print` 不用於做格式化輸出。僅作為看一下某個值的快捷方式。 多用於除錯。 完整的對輸出的控制，請使用 $string.format 以及 $io.write。'
+'接收任意數量的引數，並將它們的值列印到 `stdout`。它用 `tostring` 函式將每個引數都轉換為字串。 `print` 不用於做格式化輸出。僅作為看一下某個值的快捷方式，多用於除錯。完整的對輸出的控制，請使用 $string.format 以及 $io.write。'
 
 rawequal            =
-'在不觸發任何元方法的情況下 檢查 `v1` 是否和 `v2` 相等。 回傳一個布林值。'
+'在不觸發任何元方法的情況下，檢查 `v1` 是否和 `v2` 相等。回傳一個布林值。'
 
 rawget              =
-'在不觸發任何元方法的情況下 獲取 `table[index]` 的值。 `table` 必須是一張表； `index` 可以是任何值。'
+'在不觸發任何元方法的情況下，獲取 `table[index]` 的值。 `table` 必須是一張表； `index` 可以是任何值。'
 
 rawlen              =
-'在不觸發任何元方法的情況下 回傳對象 `v` 的長度。 `v` 可以是表或字串。 它回傳一個整數。'
+'在不觸發任何元方法的情況下，回傳物件 `v` 的長度。 `v` 可以是表或字串。它回傳一個整數。'
 
 rawset              =
 [[
-在不觸發任何元方法的情況下 將 `table[index]` 設為 `value。` `table` 必須是一張表， `index` 可以是 `nil` 與 `NaN` 之外的任何值。 `value` 可以是任何 Lua 值。
+在不觸發任何元方法的情況下，將 `table[index]` 設為 `value`。 `table` 必須是一張表， `index` 可以是 `nil` 與 `NaN` 之外的任何值。 `value` 可以是任何 Lua 值。
 這個函式回傳 `table`。
 ]]
 
 select              =
-'如果 `index` 是個數字， 那麼回傳參數中第 `index` 個之後的部分； 負的數字會從後向前索引（`-1` 指最後一個參數）。 否則，`index` 必須是字串 `"#"`， 此時 `select` 回傳參數的個數。'
+'如果 `index` 是個數字，那麼回傳引數中第 `index` 個之後的部分；負的數字會從後向前索引（`-1` 指最後一個引數）。否則， `index` 必須是字串 `"#"` ，此時 `select` 回傳引數的個數。'
 
 setfenv             =
 '設定給定函式的環境。'
 
 setmetatable        =
 [[
-給指定表設定元表。 （你不能在 Lua 中改變其它類型值的元表，那些只能在 C 裡做。） 如果 `metatable` 是 `nil`， 將指定表的元表移除。 如果原來那張元表有 `"__metatable"` 域，拋出一個錯誤。
+給指定表設定元表。（你不能在 Lua 中改變其它型別值的元表，那些只能在 C 裡做。）如果 `metatable` 是 `nil`，將指定表的元表移除。如果原來那張元表有 `"__metatable"` 域，擲回一個錯誤。
 ]]
 
 tonumber            =
 [[
-如果呼叫的時候沒有 `base`， `tonumber` 嘗試把參數轉換為一個數字。 如果參數已經是一個數字，或是一個可以轉換為數字的字串， `tonumber` 就回傳這個數字； 否則回傳 `nil`。
+如果呼叫的時候沒有 `base` ， `tonumber` 嘗試把引數轉換為一個數字。如果引數已經是一個數字，或是一個可以轉換為數字的字串， `tonumber` 就回傳這個數字，否則回傳 `nil`。
 
-字串的轉換結果可能是整數也可能是浮點數， 這取決於 Lua 的轉換文法（參見 §3.1）。 （字串可以有前置和後置的空格，可以帶符號。）
+字串的轉換結果可能是整數也可能是浮點數，這取決於 Lua 的轉換文法（參見 §3.1）。（字串可以有前置和後置的空格，可以帶符號。）
 ]]
 
 tostring            =
 [[
-可以接收任何類型，它將其轉換為人可閲讀的字串形式。 浮點數總被轉換為浮點數的表現形式（小數點形式或是指數形式）。 （如果想完全控制數字如何被轉換，可以使用 $string.format。）
-如果 `v` 有 `"__tostring"` 域的元表， `tostring` 會以 `v` 為參數呼叫它。 並用它的結果作為回傳值。
+可以接收任何型別，它將其轉換為人可閲讀的字串形式。浮點數總被轉換為浮點數的表現形式（小數點形式或是指數形式）。（如果想完全控制數字如何被轉換，可以使用 $string.format 。）
+如果 `v` 有 `"__tostring"` 域的元表， `tostring` 會以 `v` 為引數呼叫它。並用它的結果作為回傳值。
 ]]
 
 type                =
 [[
-將參數的類型編碼為一個字串回傳。 函式可能的回傳值有 `"nil"` （一個字串，而不是 `nil` 值）， `"number"`， `"string"`， `"boolean"`， `"table"`， `"function"`， `"thread"`， `"userdata"`。
+將引數的型別編碼為一個字串回傳。 函式可能的回傳值有 `"nil"` （一個字串，而不是 `nil` 值）、 `"number"` 、 `"string"` 、 `"boolean"` 、 `"table"` 、 `"function"` 、 `"thread"` 和 `"userdata"`。
 ]]
 
 _VERSION            =
 '一個包含有目前直譯器版本號的全域變數（並非函式）。'
 
 warn                =
-'使用所有參數組成的字串訊息來發送警告。'
+'使用所有引數組成的字串訊息來發送警告。'
 
 xpcall['=5.1']      =
-'傳入參數，以 *保護模式* 呼叫函式 `f` 。這個函式和 `pcall` 類似。 不過它可以額外設定一個訊息處理器 `err`。'
+'透過將函式 `f` 傳入引數，以 *保護模式* 呼叫 `f` 。這個函式和 `pcall` 類似。不過它可以額外設定一個訊息處理器 `err`。'
 xpcall['>5.2']      =
-'傳入參數，以 *保護模式* 呼叫函式 `f` 。這個函式和 `pcall` 類似。 不過它可以額外設定一個訊息處理器 `msgh`。'
+'透過將函式 `f` 傳入引數，以 *保護模式* 呼叫 `f` 。這個函式和 `pcall` 類似。不過它可以額外設定一個訊息處理器 `msgh`。'
 
 unpack              =
 [[
-回傳給定 `list` 中的所有元素。 該函式等價於
+回傳給定 `list` 中的所有元素。該函式等價於
 ```lua
 return list[i], list[i+1], ···, list[j]
 ```
@@ -227,21 +227,21 @@ assert(bit32.lshift(b, disp) ==
 coroutine                     =
 ''
 coroutine.create              =
-'新增一個主體函式為 `f` 的新共常式。 f 必須是一個 Lua 的函式。 回傳這個新共常式，它是一個類型為 `"thread"` 的對象。'
+'建立一個主體函式為 `f` 的新共常式。 f 必須是一個 Lua 的函式。回傳這個新共常式，它是一個型別為 `"thread"` 的物件。'
 coroutine.isyieldable         =
 '如果正在執行的共常式可以讓出，則回傳真。'
 coroutine.isyieldable['>5.4'] =
-'如果共常式 `co` 可以讓出，則回傳真。`co` 預設為正在執行的共常式。'
+'如果共常式 `co` 可以讓出，則回傳真。 `co` 預設為正在執行的共常式。'
 coroutine.close               =
-'關閉共常式 `co`，並關閉它所有等待 *to-be-closed* 的變數，並將共常式狀態設為 `dead` 。'
+'關閉共常式 `co` ，並關閉它所有等待 *to-be-closed* 的變數，並將共常式狀態設為 `dead` 。'
 coroutine.resume              =
 '開始或繼續共常式 `co` 的執行。'
 coroutine.running             =
-'回傳目前正在執行的共常式加一個布林值。 如果目前執行的共常式是主執行緒，其為真。'
+'回傳目前正在執行的共常式加一個布林值。如果目前執行的共常式是主執行緒，其為真。'
 coroutine.status              =
 '以字串形式回傳共常式 `co` 的狀態。'
 coroutine.wrap                =
-'新增一個主體函式為 `f` 的新共常式。 f 必須是一個 Lua 的函式。 回傳一個函式， 每次呼叫該函式都會延續該共常式。'
+'建立一個主體函式為 `f` 的新共常式。 f 必須是一個 Lua 的函式。回傳一個函式，每次呼叫該函式都會延續該共常式。'
 coroutine.yield               =
 '懸置正在呼叫的共常式的執行。'
 
@@ -257,11 +257,11 @@ costatus.dead                 =
 debug                       =
 ''
 debug.debug               =
-'進入一個使用者交互模式，執行使用者輸入的每個字串。'
+'進入一個使用者互動模式，執行使用者輸入的每個字串。'
 debug.getfenv             =
-'回傳對象 `o` 的環境。'
+'回傳物件 `o` 的環境。'
 debug.gethook             =
-'回傳三個表示執行緒鉤子設定的值： 目前鉤子函式，目前鉤子掩碼，目前鉤子計數 。'
+'回傳三個表示執行緒攔截設定的值：目前攔截函式，目前鉤子遮罩，目前鉤子計數。'
 debug.getinfo             =
 '回傳關於一個函式資訊的表。'
 debug.getlocal['<5.1']    =
@@ -277,23 +277,23 @@ debug.getupvalue          =
 debug.getuservalue['<5.3']=
 '回傳關聯在 `u` 上的 `Lua` 值。'
 debug.getuservalue['>5.4']=
-'回傳關聯在 `u` 上的第 `n` 個 `Lua` 值，以及一個布林，`false`表示值不存在。'
+'回傳關聯在 `u` 上的第 `n` 個 `Lua` 值，以及一個布林， `false` 表示值不存在。'
 debug.setcstacklimit      =
 [[
 ### **已在 `Lua 5.4.2` 中廢棄**
 
-設定新的C堆疊限制。該限制控制Lua中嵌套呼叫的深度，以避免堆疊溢出。
+設定新的C堆疊限制。該限制控制Lua中巢狀呼叫的深度，以避免堆疊溢出。
 
 如果設定成功，該函式回傳之前的限制；否則回傳`false`。
 ]]
 debug.setfenv             =
 '將 `table` 設定為 `object` 的環境。'
 debug.sethook             =
-'將一個函式作為鉤子函式設入。'
+'將一個函式作為攔截函式設入。'
 debug.setlocal            =
 '將 `value` 賦給 堆疊上第 `level` 層函式的第 `local` 個區域變數。'
 debug.setmetatable        =
-'將 `value` 的元表設為 `table` （可以是 `nil`）。'
+'將 `value` 的元表設為 `table` （可以是 `nil` ）。'
 debug.setupvalue          =
 '將 `value` 設為函式 `f` 的第 `up` 個上值。'
 debug.setuservalue['<5.3']=
@@ -301,16 +301,16 @@ debug.setuservalue['<5.3']=
 debug.setuservalue['>5.4']=
 '將 `value` 設為 `udata` 的第 `n` 個關聯值。'
 debug.traceback           =
-'回傳呼叫堆疊的堆疊回溯資訊。 字串可選項 `message` 被添加在堆疊回溯資訊的開頭。'
+'回傳呼叫堆疊的堆疊回溯資訊。字串可選項 `message` 被添加在堆疊回溯資訊的開頭。'
 debug.upvalueid           =
-'回傳指定函式第 `n` 個上值的唯一識別符（一個輕量使用者資料）。'
+'回傳指定函式第 `n` 個上值的唯一識別字（一個輕量使用者資料）。'
 debug.upvaluejoin         =
 '讓 Lua 閉包 `f1` 的第 `n1` 個上值 引用 `Lua` 閉包 `f2` 的第 `n2` 個上值。'
 
 infowhat.n                =
 '`name` 和 `namewhat`'
 infowhat.S                =
-'`source`，`short_src`，`linedefined`，`lalinedefined`，和 `what`'
+'`source` 、 `short_src` 、 `linedefined` 、 `lalinedefined` 和 `what`'
 infowhat.l                =
 '`currentline`'
 infowhat.t                =
@@ -318,7 +318,7 @@ infowhat.t                =
 infowhat.u['<5.1']        =
 '`nups`'
 infowhat.u['>5.2']        =
-'`nups`、`nparams` 和 `isvararg`'
+'`nups` 、 `nparams` 和 `isvararg`'
 infowhat.f                =
 '`func`'
 infowhat.r                =
@@ -349,13 +349,13 @@ end
 ```
 ]]
 file[':read']                =
-'讀檔案 `file`， 指定的格式決定了要讀什麼。'
+'讀取檔案 `file` ，指定的格式決定了要讀取什麼。'
 file[':seek']                =
 '設定及獲取基於檔案開頭處計算出的位置。'
 file[':setvbuf']             =
 '設定輸出檔案的緩衝模式。'
 file[':write']               =
-'將參數的值逐個寫入 `file`。'
+'將引數的值逐個寫入 `file` 。'
 
 readmode.n                  =
 '讀取一個數字，根據 Lua 的轉換文法回傳浮點數或整數。'
@@ -410,18 +410,18 @@ io.output                  =
 io.popen                   =
 '用一個分離程序開啟程式 `prog` 。'
 io.read                    =
-'讀檔案 `file`， 指定的格式決定了要讀什麼。'
+'讀取檔案 `file` ，指定的格式決定了要讀取什麼。'
 io.tmpfile                 =
 '如果成功，回傳一個臨時檔案的控制代碼。'
 io.type                    =
 '檢查 `obj` 是否是合法的檔案控制代碼。'
 io.write                   =
-'將參數的值逐個寫入預設輸出檔案。'
+'將引數的值逐個寫入預設輸出檔案。'
 
 openmode.r                 =
-'讀模式。'
+'讀取模式。'
 openmode.w                 =
-'寫模式。'
+'寫入模式。'
 openmode.a                 =
 '追加模式。'
 openmode['.r+']            =
@@ -431,9 +431,9 @@ openmode['.w+']            =
 openmode['.a+']            =
 '追加更新模式，所有之前的資料都保留，只允許在檔案尾部做寫入。'
 openmode.rb                =
-'讀模式。（二進制方式）'
+'讀取模式。（二進制方式）'
 openmode.wb                =
-'寫模式。（二進制方式）'
+'寫入模式。（二進制方式）'
 openmode.ab                =
 '追加模式。（二進制方式）'
 openmode['.r+b']           =
@@ -472,13 +472,13 @@ math.atan2                  =
 math.ceil                   =
 '回傳不小於 `x` 的最小整數值。'
 math.cos                    =
-'回傳 `x` 的餘弦（假定參數是弧度）。'
+'回傳 `x` 的餘弦（假定引數是弧度）。'
 math.cosh                   =
-'回傳 `x` 的雙曲餘弦（假定參數是弧度）。'
+'回傳 `x` 的雙曲餘弦（假定引數是弧度）。'
 math.deg                    =
 '將角 `x` 從弧度轉換為角度。'
 math.exp                    =
-'回傳 `e^x` 的值 （e 為自然對數的底）。'
+'回傳 `e^x` 的值（e 為自然對數的底）。'
 math.floor                  =
 '回傳不大於 `x` 的最大整數值。'
 math.fmod                   =
@@ -496,11 +496,11 @@ math.log['>5.2']            =
 math.log10                  =
 '回傳 `x` 的以10為底的對數。'
 math.max                    =
-'回傳參數中最大的值， 大小由 Lua 操作 `<` 決定。'
+'回傳引數中最大的值，大小由 Lua 運算子 `<` 決定。'
 math.maxinteger             =
 '最大值的整數。'
 math.min                    =
-'回傳參數中最小的值， 大小由 Lua 操作 `<` 決定。'
+'回傳引數中最小的值，大小由 Lua 運算子 `<` 決定。'
 math.mininteger             =
 '最小值的整數。'
 math.modf                   =
@@ -513,51 +513,51 @@ math.rad                    =
 '將角 `x` 從角度轉換為弧度。'
 math.random                 =
 [[
-* `math.random()`: 回傳 [0,1) 區間內均勻分佈的浮點偽隨機數。
-* `math.random(n)`: 回傳 [1, n] 區間內均勻分佈的整數偽隨機數。
-* `math.random(m, n)`: 回傳 [m, n] 區間內均勻分佈的整數偽隨機數。
+* `math.random()` ：回傳 [0,1) 區間內均勻分佈的浮點偽隨機數。
+* `math.random(n)` ：回傳 [1, n] 區間內均勻分佈的整數偽隨機數。
+* `math.random(m, n)` ：回傳 [m, n] 區間內均勻分佈的整數偽隨機數。
 ]]
 math.randomseed['<5.3']     =
 '把 `x` 設為偽隨機數發生器的“種子”： 相同的種子產生相同的隨機數列。'
 math.randomseed['>5.4']     =
 [[
-* `math.randomseed(x, y)`: 將 `x` 與 `y` 連接為128位的種子來重新初始化偽隨機生成器。
-* `math.randomseed(x)`: 等同於 `math.randomseed(x, 0)` 。
-* `math.randomseed()`: 生成一個較弱的隨機種子。
+* `math.randomseed(x, y)` ：將 `x` 與 `y` 連接為128位的種子來重新初始化偽隨機產生器。
+* `math.randomseed(x)` ：等同於 `math.randomseed(x, 0)` 。
+* `math.randomseed()` ：產生一個較弱的隨機種子。
 ]]
 math.sin                    =
-'回傳 `x` 的正弦值（假定參數是弧度）。'
+'回傳 `x` 的正弦值（假定引數是弧度）。'
 math.sinh                   =
-'回傳 `x` 的雙曲正弦值（假定參數是弧度）。'
+'回傳 `x` 的雙曲正弦值（假定引數是弧度）。'
 math.sqrt                   =
 '回傳 `x` 的平方根。'
 math.tan                    =
-'回傳 `x` 的正切值（假定參數是弧度）。'
+'回傳 `x` 的正切值（假定引數是弧度）。'
 math.tanh                   =
-'回傳 `x` 的雙曲正切值（假定參數是弧度）。'
+'回傳 `x` 的雙曲正切值（假定引數是弧度）。'
 math.tointeger              =
-'如果 `x` 可以轉換為一個整數， 回傳該整數。'
+'如果 `x` 可以轉換為一個整數，回傳該整數。'
 math.type                   =
-'如果 `x` 是整數，回傳 `"integer"`， 如果它是浮點數，回傳 `"float"`， 如果 `x` 不是數字，回傳 `nil`。'
+'如果 `x` 是整數，回傳 `"integer"` ，如果它是浮點數，回傳 `"float"` ，如果 `x` 不是數字，回傳 `nil` 。'
 math.ult                    =
-'如果整數 `m` 和 `n` 以無符號整數形式比較， `m` 在 `n` 之下，回傳布林真否則回傳假。'
+'整數 `m` 和 `n` 以無符號整數形式比較，如果 `m` 在 `n` 之下則回傳布林真，否則回傳假。'
 
 os                          =
 ''
 os.clock                    =
 '回傳程式使用的按秒計 CPU 時間的近似值。'
 os.date                     =
-'回傳一個包含日期及時刻的字串或表。 格式化方法取決於所給字串 `format`。'
+'回傳一個包含日期及時刻的字串或表。格式化方法取決於所給字串 `format` 。'
 os.difftime                 =
 '回傳以秒計算的時刻 `t1` 到 `t2` 的差值。'
 os.execute                  =
-'呼叫系統直譯器執行 `command`。'
+'呼叫系統直譯器執行 `command` 。'
 os.exit['<5.1']             =
 '呼叫 C 函式 `exit` 終止宿主程式。'
 os.exit['>5.2']             =
 '呼叫 ISO C 函式 `exit` 終止宿主程式。'
 os.getenv                   =
-'回傳程序環境變數 `varname` 的值。'
+'回傳處理程序環境變數 `varname` 的值。'
 os.remove                   =
 '刪除指定名字的檔案。'
 os.rename                   =
@@ -565,7 +565,7 @@ os.rename                   =
 os.setlocale                =
 '設定程式的目前區域。'
 os.time                     =
-'當不傳參數時，回傳目前時刻。 如果傳入一張表，就回傳由這張表表示的時刻。'
+'當不傳引數時，回傳目前時刻。如果傳入一張表，就回傳由這張表表示的時刻。'
 os.tmpname                  =
 '回傳一個可用於臨時檔案的檔名字串。'
 
@@ -582,19 +582,19 @@ osdate.min                  =
 osdate.sec                  =
 '0-61'
 osdate.wday                 =
-'星期幾，1-7，星期天為 1'
+'星期幾，範圍為1-7，星期天為 1'
 osdate.yday                 =
-'當年的第幾天，1-366'
+'該年的第幾天，範圍為1-366'
 osdate.isdst                =
-'夏令時標記，一個布林值'
+'夏令時間，一個布林值'
 
 package                     =
 ''
 
 require['<5.3']             =
-'載入一個模組，回傳該模組的回傳值（`nil`時為`true`）。'
+'載入一個模組，回傳該模組的回傳值（ `nil` 時為 `true` ）。'
 require['>5.4']             =
-'載入一個模組，回傳該模組的回傳值（`nil`時為`true`）與搜尋器回傳的載入資料。預設搜尋器的載入資料指示了載入位置，對於檔案來説就是檔案路徑。'
+'載入一個模組，回傳該模組的回傳值（ `nil` 時為 `true` ）與搜尋器回傳的載入資料。預設搜尋器的載入資料指示了載入位置，對於檔案來説就是檔案路徑。'
 
 package.config              =
 '一個描述有一些為包管理準備的編譯時期組態訊息的串。'
@@ -605,7 +605,7 @@ package.loaded              =
 package.loaders             =
 '用於 `require` 控制如何載入模組的表。'
 package.loadlib             =
-'讓宿主程式動態連接 C 庫 `libname` 。'
+'讓宿主程式動態連結 C 庫 `libname` 。'
 package.path                =
 '這個路徑被 `require` 在 Lua 載入器中做搜尋時用到。'
 package.preload             =
@@ -620,18 +620,18 @@ package.seeall              =
 string                      =
 ''
 string.byte                 =
-'回傳字元 `s[i]`， `s[i+1]`， ...　，`s[j]` 的內部數字編碼。'
+'回傳字元 `s[i]` 、 `s[i+1]` ... `s[j]` 的內部數字編碼。'
 string.char                 =
-'接收零或更多的整數。 回傳和參數數量相同長度的字串。 其中每個字元的內部編碼值等於對應的參數值。'
+'接收零或更多的整數，回傳和引數數量相同長度的字串。其中每個字元的內部編碼值等於對應的引數值。'
 string.dump                 =
 '回傳包含有以二進制方式表示的（一個 *二進制程式碼區塊* ）指定函式的字串。'
 string.find                 =
-'查找第一個字串中匹配到的 `pattern`（參見 §6.4.1）。'
+'尋找第一個字串中配對到的 `pattern`（參見 §6.4.1）。'
 string.format               =
-'回傳不定數量參數的格式化版本，格式化串為第一個參數。'
+'回傳不定數量引數的格式化版本，格式化字串為第一個引數。'
 string.gmatch               =
 [[
-回傳一個疊代器函式。 每次呼叫這個函式都會繼續以 `pattern` （參見　§6.4.1） 對 s 做匹配，並回傳所有捕獲到的值。
+回傳一個疊代器函式。每次呼叫這個函式都會繼續以 `pattern` （參見　§6.4.1）對 s 做配對，並回傳所有捕獲到的值。
 
 下面這個例子會循環疊代字串 s 中所有的單詞， 並逐行列印：
 ```lua
@@ -643,27 +643,27 @@ string.gmatch               =
 ```
 ]]
 string.gsub                 =
-'將字串 s 中，所有的（或是在 n 給出時的前 n 個） pattern （參見 §6.4.1）都替換成 repl ，並回傳其副本。'
+'將字串 s 中，所有的（或是在 n 給出時的前 n 個） `pattern` （參見 §6.4.1）都替換成 `repl` ，並回傳其副本。'
 string.len                  =
 '回傳其長度。'
 string.lower                =
 '將其中的大寫字元都轉為小寫後回傳其副本。'
 string.match                =
-'在字串 s 中找到第一個能用 pattern （參見 §6.4.1）匹配到的部分。 如果能找到，match 回傳其中的捕獲物； 否則回傳 nil 。'
+'在字串 s 中找到第一個能用 `pattern` （參見 §6.4.1）配對到的部分。如果能找到，回傳其中的捕獲物，否則回傳 `nil` 。'
 string.pack                 =
-'回傳一個打包了（即以二進制形式序列化） v1, v2 等值的二進制字串。 字串 fmt 為打包格式（參見 §6.4.2）。'
+'回傳一個壓縮了（即以二進制形式序列化） v1, v2 等值的二進制字串。字串 `fmt` 為壓縮格式（參見 §6.4.2）。'
 string.packsize             =
-[[回傳以指定格式用 $string.pack 打包的字串的長度。 格式化字串中不可以有變長選項 's' 或 'z' （參見 §6.4.2）。]]
+[[回傳以指定格式用 $string.pack 壓縮的字串的長度。格式化字串中不可以有變長選項 's' 或 'z' （參見 §6.4.2）。]]
 string.rep['>5.2']          =
-'回傳 `n` 個字串 `s` 以字串 `sep` 為分割符連在一起的字串。 預設的 `sep` 值為空字串（即沒有分割符）。 如果 `n` 不是正數則回傳空串。'
+'回傳 `n` 個字串 `s` 以字串 `sep` 為分割符連在一起的字串。預設的 `sep` 值為空字串（即沒有分割符）。如果 `n` 不是正數則回傳空字串。'
 string.rep['<5.1']          =
-'回傳 `n` 個字串 `s` 連在一起的字串。 如果 `n` 不是正數則回傳空串。'
+'回傳 `n` 個字串 `s` 連在一起的字串。如果 `n` 不是正數則回傳空字串。'
 string.reverse              =
-'回傳字串 s 的翻轉串。'
+'回傳字串 s 的反轉字串。'
 string.sub                  =
-'回傳字串的子串， 該子串從 `i` 開始到 `j` 為止。'
+'回傳一個從 `i` 開始並在 `j` 結束的子字串。'
 string.unpack               =
-'回傳以格式 fmt （參見 §6.4.2） 打包在字串 s （參見 string.pack） 中的值。'
+'回傳以格式 `fmt` （參見 §6.4.2） 壓縮在字串 `s` （參見 $string.pack） 中的值。'
 string.upper                =
 '接收一個字串，將其中的小寫字元都轉為大寫後回傳其副本。'
 
@@ -685,45 +685,45 @@ return a2
 ```
 ]]
 table.pack                  =
-'回傳用所有參數以鍵 `1`,`2`, 等填充的新表， 並將 `"n"` 這個域設為參數的總數。'
+'回傳用所有引數以鍵 `1`,`2`, 等填充的新表，並將 `"n"` 這個域設為引數的總數。'
 table.remove                =
 '移除 `list` 中 `pos` 位置上的元素，並回傳這個被移除的值。'
 table.sort                  =
 '在表內從 `list[1]` 到 `list[#list]` *原地* 對其間元素按指定順序排序。'
 table.unpack                =
 [[
-回傳列表中的元素。 這個函式等價於
+回傳列表中的元素。這個函式等價於
 ```lua
     return list[i], list[i+1], ···, list[j]
 ```
-i 預設為 1 ，j 預設為 #list。
+i 預設為 1 ， j 預設為 #list。
 ]]
 table.foreach               =
-'走訪表中的每一個元素，並以key和value執行回呼函式。如果回呼函式回傳一個非nil值則循環終止,並且回傳這個值。該函式等同pair(list),比pair(list)更慢。不推薦使用'
+'走訪表中的每一個元素，並以key和value執行回呼函式。如果回呼函式回傳一個非nil值則循環終止，並且回傳這個值。該函式等同pair(list)，比pair(list)更慢。不推薦使用。'
 table.foreachi              =
-'走訪表中的每一個元素，並以索引號index和value執行回呼函式。如果回呼函式回傳一個非nil值則循環終止,並且回傳這個值。該函式等同ipair(list),比ipair(list)更慢。不推薦使用'
+'走訪表中的每一個元素，並以索引號index和value執行回呼函式。如果回呼函式回傳一個非nil值則循環終止，並且回傳這個值。該函式等同ipair(list)，比ipair(list)更慢。不推薦使用。'
 table.getn                  =
 '回傳表的長度。該函式等價於#list。'
-table.new                   = -- TODO: need translate!
-[[This creates a pre-sized table, just like the C API equivalent `lua_createtable()`. This is useful for big tables if the final table size is known and automatic table resizing is too expensive. `narray` parameter specifies the number of array-like items, and `nhash` parameter specifies the number of hash-like items. The function needs to be required before use.
+table.new                   =
+[[這將建立一個預先確定大小的表，就像和 C API 等價的 `lua_createtable()` 一樣。如果已確定最終表的大小，而且自動更改大小很耗效能的話，這對大表很有用。 `narray` 參數指定像陣列般元素的數量，而 `nhash` 參數指定像雜湊般元素的數量。使用這個函式前需要先 require。
 ```lua
     require("table.new")
 ```
 ]]
-table.clear                 = -- TODO: need translate!
-[[This clears all keys and values from a table, but preserves the allocated array/hash sizes. This is useful when a table, which is linked from multiple places, needs to be cleared and/or when recycling a table for use by the same context. This avoids managing backlinks, saves an allocation and the overhead of incremental array/hash part growth. The function needs to be required before use.
+table.clear                 =
+[[這會清除表中的所有的鍵值對，但保留分配的陣列或雜湊大小。當需要清除從多個位置連結的表，或回收表以供同一上下文使用時很有用。這避免了管理反向連結，節省了分配和增加陣列/雜湊部分而增長的開銷。使用這個函式前需要先 require。
 ```lua
-    require("table.clear").
+    require("table.clear")
 ```
-Please note this function is meant for very specific situations. In most cases it's better to replace the (usually single) link with a new table and let the GC do its work.
+請注意，此函式適用於非常特殊的情況。在大多數情況下，最好用新表替換（通常是單個）連結，並讓垃圾回收完成工作。
 ]]
 
 utf8                        =
 ''
 utf8.char                   =
-'接收零或多個整數， 將每個整數轉換成對應的 UTF-8 位元組序列，並回傳這些序列連接到一起的字串。'
+'接收零或多個整數，將每個整數轉換成對應的 UTF-8 位元組序列，並回傳這些序列連接到一起的字串。'
 utf8.charpattern            =
-'用於精確匹配到一個 UTF-8 位元組序列的模式，它假定處理的對象是一個合法的 UTF-8 字串。'
+'用於精確配對到一個 UTF-8 位元組序列的模式，它假定處理的對象是一個合法的 UTF-8 字串。'
 utf8.codes                  =
 [[
 回傳一系列的值，可以讓
@@ -732,11 +732,11 @@ for p, c in utf8.codes(s) do
     body
 end
 ```
-疊代出字串 s 中所有的字元。 這裡的 p 是位置（按位元組數）而 c 是每個字元的編號。 如果處理到一個不合法的位元組序列，將拋出一個錯誤。
+疊代出字串 `s` 中所有的字元。這裡的 `p` 是位置（按位元組數）而 `c` 是每個字元的編號。如果處理到一個不合法的位元組序列，將擲回一個錯誤。
 ]]
 utf8.codepoint              =
-'以整數形式回傳 `s` 中 從位置 `i` 到 `j` 間（包括兩端） 所有字元的編號。'
+'以整數形式回傳 `s` 中 從位置 `i` 到 `j` 間（包括兩端）所有字元的編號。'
 utf8.len                    =
 '回傳字串 `s` 中 從位置 `i` 到 `j` 間 （包括兩端） UTF-8 字元的個數。'
 utf8.offset                 =
-'回傳編碼在 `s` 中的第 `n` 個字元的開始位置（按位元組數） （從位置 `i` 處開始統計）。'
+'回傳編碼在 `s` 中的第 `n` 個字元的開始位置（按位元組數）（從位置 `i` 處開始統計）。'

--- a/locale/zh-tw/script.lua
+++ b/locale/zh-tw/script.lua
@@ -13,15 +13,15 @@ DIAG_UNDEF_ENV_CHILD    =
 DIAG_UNDEF_FENV_CHILD   =
 '未定義的變數 `{}`（處於模組中）。'
 DIAG_GLOBAL_IN_NIL_ENV  =
-'不能使用全域變數（`_ENV`被設為了`nil`）。'
+'不能使用全域變數（ `_ENV` 被設為了 `nil` ）。'
 DIAG_GLOBAL_IN_NIL_FENV =
-'不能使用全域變數（模組被設為了`nil`）。'
+'不能使用全域變數（模組被設為了 `nil` ）。'
 DIAG_UNUSED_LABEL       =
 '未使用的標籤 `{}`。'
 DIAG_UNUSED_FUNCTION    =
 '未使用的函式。'
 DIAG_UNUSED_VARARG      =
-'未使用的不定參數。'
+'未使用的不定引數。'
 DIAG_REDEFINED_LOCAL    =
 '重複定義區域變數 `{}`。'
 DIAG_DUPLICATE_INDEX    =
@@ -29,17 +29,17 @@ DIAG_DUPLICATE_INDEX    =
 DIAG_DUPLICATE_METHOD   =
 '重複的方法 `{}`。'
 DIAG_PREVIOUS_CALL      =
-'會被直譯為 `{}{}`。你可能需要加一個 `;`。'
+'會被直譯為 `{}{}` 。你可能需要加一個 `;`。'
 DIAG_PREFIELD_CALL      =
-'會被直譯為 `{}{}`。你可能需要加一個`,`或`;`。'
+'會被直譯為 `{}{}` 。你可能需要加一個 `,` 或 `;` 。'
 DIAG_OVER_MAX_ARGS      =
-'函式最多接收 {:d} 個參數，但獲得了 {:d} 個。'
+'函式最多接收 {:d} 個引數，但獲得了 {:d} 個。'
 DIAG_MISS_ARGS          =
-'函式最少接收 {:d} 個參數，但獲得了 {:d} 個。'
+'函式最少接收 {:d} 個引數，但獲得了 {:d} 個。'
 DIAG_OVER_MAX_VALUES    =
 '只有 {} 個變數，但你設定了 {} 個值。'
 DIAG_AMBIGUITY_1        =
-'會優先運算 `{}`，你可能需要加個括號。'
+'會優先運算 `{}` ，你可能需要加個括號。'
 DIAG_LOWERCASE_GLOBAL   =
 '首字母小寫的全域變數，你是否漏了 `local` 或是有拼寫錯誤？'
 DIAG_EMPTY_BLOCK        =
@@ -79,21 +79,21 @@ DIAG_UNBALANCED_ASSIGNMENTS =
 DIAG_REQUIRE_LIKE       =
 '你可以在設定中將 `{}` 視為 `require`。'
 DIAG_COSE_NON_OBJECT    =
-'無法 close 此類型的值。（除非給此類型設定 `__close` 元方法）'
+'無法 close 此型別的值。（除非給此型別設定 `__close` 元方法）'
 DIAG_COUNT_DOWN_LOOP    =
 '你的意思是 `{}` 嗎？'
 DIAG_UNKNOWN            =
-'無法推測出類型。'
+'無法推測出型別。'
 DIAG_DEPRECATED         =
 '已廢棄。'
 DIAG_DIFFERENT_REQUIRES =
-'使用了不同的名字 require 了同一個檔案。'
+'使用了不同的名字 `require` 了同一個檔案。'
 DIAG_REDUNDANT_RETURN   =
 '冗餘回傳。'
 DIAG_AWAIT_IN_SYNC      =
-'只能在標記為異步的函式中呼叫異步函式。'
+'只能在標記為非同步的函式中呼叫非同步函式。'
 DIAG_NOT_YIELDABLE      =
-'此函式的第 {} 個參數沒有被標記為可讓出，但是傳入了異步函式。（使用 `---@param name async fun()` 來標記為可讓出）'
+'此函式的第 {} 個參數沒有被標記為可讓出，但是傳入了非同步函式。（使用 `---@param name async fun()` 來標記為可讓出）'
 DIAG_DISCARD_RETURNS    =
 '不能丟棄此函式的回傳值。'
 DIAG_NEED_CHECK_NIL     =
@@ -111,7 +111,7 @@ DIAG_DUPLICATE_DOC_PARAM              =
 DIAG_UNDEFINED_DOC_CLASS              =
 '未定義的類別 `{}`。'
 DIAG_UNDEFINED_DOC_NAME               =
-'未定義的類型或別名 `{}`。'
+'未定義的型別或別名 `{}`。'
 DIAG_UNDEFINED_DOC_PARAM              =
 '指向了未定義的參數 `{}`。'
 DIAG_UNKNOWN_DIAG_CODE                =
@@ -142,10 +142,10 @@ WORKSPACE_DIAGNOSTIC      =
 '正在對工作目錄進行診斷'
 WORKSPACE_SKIP_HUGE_FILE  =
 '出於效能考慮，已停止對此檔案解析：{}'
-WORKSPACE_NOT_ALLOWED     = -- TODO: need translate!
-'Your workspace is set to `{}`. Lua language server refused to load this directory. Please check your configuration.[learn more here](https://github.com/sumneko/lua-language-server/wiki/Why-scanning-home-folder)'
-WORKSPACE_SCAN_TOO_MUCH   = -- TODO: need translate!
-'More than {} files have been scanned. The current scanned directory is `{}`. Please confirm whether the configuration is correct.'
+WORKSPACE_NOT_ALLOWED     =
+'你的工作目錄被設定為了 `{}` ，Lua語言服務拒絕載入此目錄，請檢查你的設定檔。[了解更多](https://github.com/sumneko/lua-language-server/wiki/Why-scanning-home-folder)'
+WORKSPACE_SCAN_TOO_MUCH   =
+'已掃描了超過 {} 個檔案，目前掃描的目錄為 `{}`，請確認設定檔是否正確。'
 
 PARSER_CRASH            =
 '語法解析崩潰了！遺言：{}'
@@ -176,11 +176,11 @@ PARSER_MISS_FIELD       =
 PARSER_MISS_METHOD      =
 '缺少方法名。'
 PARSER_ARGS_AFTER_DOTS  =
-'`...`必須是最後一個參數。'
+'`...`必須是最後一個引數。'
 PARSER_KEYWORD          =
 '關鍵字無法作為名稱。'
 PARSER_EXP_IN_ACTION    =
-'該表達式不能作為語句。'
+'該表達式不能作為敘述。'
 PARSER_BREAK_OUTSIDE    =
 '`break`必須在循環內部。'
 PARSER_MALFORMED_NUMBER =
@@ -204,47 +204,47 @@ PARSER_UNKNOWN_TAG      =
 PARSER_MULTI_TAG        =
 '只能設定一個屬性。'
 PARSER_UNEXPECT_LFUNC_NAME =
-'區域函式只能使用識別符作為名稱。'
+'區域函式只能使用識別字作為名稱。'
 PARSER_UNEXPECT_EFUNC_NAME =
 '函式作為表達式時不能命名。'
 PARSER_ERR_LCOMMENT_END =
-'應使用`{symbol}`來關閉多行註解。'
+'應使用 `{symbol}` 來關閉多行註解。'
 PARSER_ERR_C_LONG_COMMENT =
-'Lua應使用`--[[ ]]`來進行多行註解。'
+'Lua應使用 `--[[ ]]` 來進行多行註解。'
 PARSER_ERR_LSTRING_END  =
-'應使用`{symbol}`來關閉長字串。'
+'應使用 `{symbol}` 來關閉長字串。'
 PARSER_ERR_ASSIGN_AS_EQ =
-'應使用`=`來進行賦值操作。'
+'應使用 `=` 來進行賦值操作。'
 PARSER_ERR_EQ_AS_ASSIGN =
-'應使用`==`來進行等於判斷。'
+'應使用 `==` 來進行等於判斷。'
 PARSER_ERR_UEQ          =
-'應使用`~=`來進行不等於判斷。'
+'應使用 `~=` 來進行不等於判斷。'
 PARSER_ERR_THEN_AS_DO   =
-'應使用`then`。'
+'應使用 `then` 。'
 PARSER_ERR_DO_AS_THEN   =
-'應使用`do`。'
+'應使用 `do` 。'
 PARSER_MISS_END         =
-'缺少對應的`end`。'
+'缺少對應的 `end` 。'
 PARSER_ERR_COMMENT_PREFIX =
-'Lua應使用`--`來進行註解。'
+'Lua應使用 `--` 來進行註解。'
 PARSER_MISS_SEP_IN_TABLE =
-'需要用`,`或`;`進行分割。'
+'需要用 `,` 或 `;` 進行分割。'
 PARSER_SET_CONST         =
 '不能對常數賦值。'
 PARSER_UNICODE_NAME      =
 '包含了 Unicode 字元。'
 PARSER_ERR_NONSTANDARD_SYMBOL =
-'Lua中應使用符號 `{symbol}`。'
+'Lua中應使用符號 `{symbol}` 。'
 PARSER_MISS_SPACE_BETWEEN =
-'符號之間必須保留空格'
+'符號之間必須保留空格。'
 PARSER_INDEX_IN_FUNC_NAME =
 '命名函式的名稱中不能使用 `[name]` 形式。'
 PARSER_UNKNOWN_ATTRIBUTE  =
-'區域變數屬性應該是 `const` 或 `close`'
+'區域變數屬性應該是 `const` 或 `close` 。'
 PARSER_LUADOC_MISS_CLASS_NAME           =
 '缺少類別名稱。'
 PARSER_LUADOC_MISS_EXTENDS_SYMBOL       =
-'缺少符號 `:`。'
+'缺少符號 `:` 。'
 PARSER_LUADOC_MISS_CLASS_EXTENDS_NAME   =
 '缺少要繼承的類別名稱。'
 PARSER_LUADOC_MISS_SYMBOL               =
@@ -252,7 +252,7 @@ PARSER_LUADOC_MISS_SYMBOL               =
 PARSER_LUADOC_MISS_ARG_NAME             =
 '缺少參數名稱。'
 PARSER_LUADOC_MISS_TYPE_NAME            =
-'缺少類型名。'
+'缺少型別名。'
 PARSER_LUADOC_MISS_ALIAS_NAME           =
 '缺少別名。'
 PARSER_LUADOC_MISS_ALIAS_EXTENDS        =
@@ -260,21 +260,21 @@ PARSER_LUADOC_MISS_ALIAS_EXTENDS        =
 PARSER_LUADOC_MISS_PARAM_NAME           =
 '缺少要指向的參數名稱。'
 PARSER_LUADOC_MISS_PARAM_EXTENDS        =
-'缺少參數的類型定義。'
+'缺少參數的型別定義。'
 PARSER_LUADOC_MISS_FIELD_NAME           =
 '缺少欄位名稱。'
 PARSER_LUADOC_MISS_FIELD_EXTENDS        =
-'缺少欄位的類型定義。'
+'缺少欄位的型別定義。'
 PARSER_LUADOC_MISS_GENERIC_NAME         =
 '缺少泛型名稱。'
 PARSER_LUADOC_MISS_GENERIC_EXTENDS_NAME =
 '缺少泛型要繼承的類別名稱。'
 PARSER_LUADOC_MISS_VARARG_TYPE          =
-'缺少可變參數的類型定義。'
+'缺少可變引數的型別定義。'
 PARSER_LUADOC_MISS_FUN_AFTER_OVERLOAD   =
-'缺少關鍵字 `fun`。'
+'缺少關鍵字 `fun` 。'
 PARSER_LUADOC_MISS_CATE_NAME            =
-'缺少文件類型名稱。'
+'缺少文件型別名稱。'
 PARSER_LUADOC_MISS_DIAG_MODE            =
 '缺少診斷模式。'
 PARSER_LUADOC_ERROR_DIAG_MODE           =
@@ -286,7 +286,7 @@ SYMBOL_ANONYMOUS        =
 '<匿名函式>'
 
 HOVER_VIEW_DOCUMENTS    =
-'查看文件'
+'檢視文件'
 HOVER_DOCUMENT_LUA51    =
 'https://www.lua.org/manual/5.1/manual.html#{}'
 HOVER_DOCUMENT_LUA52    =
@@ -308,25 +308,25 @@ HOVER_NATIVE_DOCUMENT_LUA54     =
 HOVER_NATIVE_DOCUMENT_LUAJIT    =
 'command:extension.lua.doc?["en-us/51/manual.html/{}"]'
 HOVER_MULTI_PROTOTYPE      =
-'({} 個原型)'
+'（{} 個原型）'
 HOVER_STRING_BYTES         =
 '{} 個位元組'
 HOVER_STRING_CHARACTERS    =
 '{} 個位元組，{} 個字元'
 HOVER_MULTI_DEF_PROTO      =
-'({} 個定義，{} 個原型)'
+'（{} 個定義，{} 個原型）'
 HOVER_MULTI_PROTO_NOT_FUNC =
-'({} 個非函式定義)'
+'（{} 個非函式定義）'
 HOVER_USE_LUA_PATH      =
-'（搜尋路徑： `{}`）'
+'（搜尋路徑： `{}` ）'
 HOVER_EXTENDS           =
 '展開為 {}'
 HOVER_TABLE_TIME_UP     =
-'出於效能考慮，已停用了部分類型推斷。'
+'出於效能考慮，已停用了部分型別推斷。'
 HOVER_WS_LOADING        =
 '正在載入工作目錄：{} / {}'
 HOVER_AWAIT_TOOLTIP     =
-'正在呼叫異步函式，可能會讓出目前共常式'
+'正在呼叫非同步函式，可能會讓出目前共常式'
 
 ACTION_DISABLE_DIAG     =
 '在工作區停用診斷 ({})。'
@@ -383,7 +383,7 @@ ACTION_DISABLE_DIAG_LINE=
 ACTION_DISABLE_DIAG_FILE=
 '在此檔案停用診斷 ({})。'
 ACTION_MARK_ASYNC       =
-'將目前函式標記為異步。'
+'將目前函式標記為非同步。'
 
 COMMAND_DISABLE_DIAG       =
 '停用診斷'
@@ -405,7 +405,7 @@ COMMAND_JSON_TO_LUA_FAILED =
 'JSON 轉 Lua 失敗：{}'
 
 COMPLETION_IMPORT_FROM           =
-'從 {} 中導入'
+'從 {} 中匯入'
 COMPLETION_DISABLE_AUTO_REQUIRE  =
 '停用自動require'
 COMPLETION_ASK_AUTO_REQUIRE      =
@@ -474,7 +474,7 @@ WINDOW_LUA_STATUS_DIAGNOSIS_TITLE=
 WINDOW_LUA_STATUS_DIAGNOSIS_MSG  =
 '是否進行工作區診斷？'
 WINDOW_APPLY_SETTING             =
-'應用設定'
+'套用設定'
 WINDOW_CHECK_SEMANTIC            =
 '如果你正在使用市場中的顏色主題，你可能需要同時修改 `editor.semanticHighlighting.enabled` 選項為 `true` 才會使語義著色生效。'
 WINDOW_TELEMETRY_HINT            =
@@ -484,9 +484,9 @@ WINDOW_TELEMETRY_ENABLE          =
 WINDOW_TELEMETRY_DISABLE         =
 '禁止'
 WINDOW_CLIENT_NOT_SUPPORT_CONFIG =
-'你的使用者端不支援從伺服端修改設定，請手動修改如下設定：'
+'你的用戶端不支援從伺服端修改設定，請手動修改以下設定：'
 WINDOW_LCONFIG_NOT_SUPPORT_CONFIG=
-'暫不支援自動修改本地設定，請手動修改如下設定：'
+'暫時不支援自動修改本地設定，請手動修改以下設定：'
 WINDOW_MANUAL_CONFIG_ADD         =
 '為 `{key}` 添加值 `{value:q}`;'
 WINDOW_MANUAL_CONFIG_SET         =
@@ -494,9 +494,9 @@ WINDOW_MANUAL_CONFIG_SET         =
 WINDOW_MANUAL_CONFIG_PROP        =
 '將 `{key}` 的屬性 `{prop}` 設定為 `{value:q}`;'
 WINDOW_APPLY_WHIT_SETTING        =
-'應用並修改設定'
+'套用並修改設定'
 WINDOW_APPLY_WHITOUT_SETTING     =
-'應用但不修改設定'
+'套用但不修改設定'
 WINDOW_ASK_APPLY_LIBRARY         =
 '是否需要將你的工作環境配置為 `{}` ？'
 WINDOW_SEARCHING_IN_FILES        =

--- a/locale/zh-tw/setting.lua
+++ b/locale/zh-tw/setting.lua
@@ -4,7 +4,7 @@ config.runtime.version            =
 "Lua執行版本。"
 config.runtime.path               =
 [[
-當使用 `require` 時，如何根據輸入的名字來查找檔案。
+當使用 `require` 時，如何根據輸入的名字來尋找檔案。
 此選項設定為 `?/init.lua` 意味著當你輸入 `require 'myfile'` 時，會從已載入的檔案中搜尋 `{workspace}/myfile/init.lua`。
 當 `runtime.pathStrict` 設定為 `false` 時，還會嘗試搜尋 `${workspace}/**/myfile/init.lua`。
 如果你想要載入工作區以外的檔案，你需要先設定 `Lua.workspace.library`。
@@ -12,7 +12,7 @@ config.runtime.path               =
 config.runtime.pathStrict         =
 '啟用後 `runtime.path` 將只搜尋第一層目錄，見 `runtime.path` 的説明。'
 config.runtime.special            =
-[[將自定義全域變數視為一些特殊的內建變數，語言服務將提供特殊的支援。
+[[將自訂全域變數視為一些特殊的內建變數，語言服務將提供特殊的支援。
 下面這個例子表示將 `include` 視為 `require` 。
 ```json
 "Lua.runtime.special" : {
@@ -51,7 +51,7 @@ config.diagnostics.neededFileStatus =
 * Disable: 停用此診斷
 ]]
 config.diagnostics.workspaceDelay =
-"進行工作區診斷的延遲（毫秒）。當你啟動工作區，或編輯了任意檔案後，將會在後台對整個工作區進行重新診斷。設定為負數可以停用工作區診斷。"
+"進行工作區診斷的延遲（毫秒）。當你啟動工作區，或編輯了任意檔案後，將會在背景對整個工作區進行重新診斷。設定為負數可以停用工作區診斷。"
 config.diagnostics.workspaceRate  =
 "工作區診斷的執行速率（百分比）。降低該值會減少CPU佔用，但是也會降低工作區診斷的速度。你目前正在編輯的檔案的診斷總是全速完成，不受該選項影響。"
 config.diagnostics.libraryFiles   =
@@ -64,8 +64,8 @@ config.diagnostics.files.Opened   =
 "只有打開這些檔案時才會診斷。"
 config.diagnostics.files.Disable  =
 "不診斷這些檔案。"
-config.diagnostics.disableScheme  = -- TODO: need translate!
-'不诊断使用以下 scheme 的lua文件。'
+config.diagnostics.disableScheme  =
+'不診斷使用以下 scheme 的lua檔案。'
 config.workspace.ignoreDir        =
 "忽略的檔案與目錄（使用 `.gitignore` 語法）。"
 config.workspace.ignoreSubmodules =
@@ -77,10 +77,10 @@ config.workspace.maxPreload       =
 config.workspace.preloadFileSize  =
 "預載入時跳過大小大於該值（KB）的檔案。"
 config.workspace.library          =
-"除了目前工作區以外，還會從哪些目錄中載入檔案。這些目錄中的檔案將被視作外部提供的程式碼庫，部分操作（如重命名欄位）不會修改這些檔案。"
+"除了目前工作區以外，還會從哪些目錄中載入檔案。這些目錄中的檔案將被視作外部提供的程式碼庫，部分操作（如重新命名欄位）不會修改這些檔案。"
 config.workspace.checkThirdParty  =
 [[
-自動檢測與適應第三方庫，目前支援的庫為：
+自動偵測與適應第三方庫，目前支援的庫為：
 
 * OpenResty
 * Cocos4.0
@@ -91,8 +91,8 @@ config.workspace.checkThirdParty  =
 ]]
 config.workspace.userThirdParty          =
 '在這裡添加私有的第三方庫適應檔案路徑，請參考內建的[組態檔案路徑](https://github.com/sumneko/lua-language-server/tree/master/meta/3rd)'
-config.workspace.supportScheme           = -- TODO: need translate!
-'为以下 scheme 的lua文件提供语言服务。'
+config.workspace.supportScheme           =
+'為以下 `scheme` 的lua檔案提供語言服務。'
 config.completion.enable                 =
 '啟用自動完成。'
 config.completion.callSnippet            =
@@ -104,7 +104,7 @@ config.completion.callSnippet.Both       =
 config.completion.callSnippet.Replace    =
 "只顯示 `呼叫片段`。"
 config.completion.keywordSnippet         =
-'顯示關鍵字語法片段'
+'顯示關鍵字語法片段。'
 config.completion.keywordSnippet.Disable =
 "只顯示 `關鍵字`。"
 config.completion.keywordSnippet.Both    =
@@ -112,7 +112,7 @@ config.completion.keywordSnippet.Both    =
 config.completion.keywordSnippet.Replace =
 "只顯示 `語法片段`。"
 config.completion.displayContext         =
-"預覽建議的相關程式碼片段，可能可以幫助你瞭解這項建議的用法。設定的數字表示程式碼片段的擷取行數，設定為`0`可以停用此功能。"
+"預覽建議的相關程式碼片段，可能可以幫助你瞭解這項建議的用法。設定的數字表示程式碼片段的擷取行數，設定為 `0` 可以停用此功能。"
 config.completion.workspaceWord          =
 "顯示的上下文單詞是否包含工作區中其他檔案的內容。"
 config.completion.showWord               =
@@ -136,7 +136,7 @@ config.color.mode                        =
 config.color.mode.Semantic               =
 "語義著色。你可能需要同時將 `editor.semanticHighlighting.enabled` 設定為 `true` 才能生效。"
 config.color.mode.SemanticEnhanced       =
-"增強的語義顏色。 類似於`Semantic`，但會進行額外的分析（也會帶來額外的開銷）。"
+"增強的語義顏色。類似於`Semantic`，但會進行額外的分析（也會帶來額外的開銷）。"
 config.color.mode.Grammar                =
 "語法著色。"
 config.semantic.enable                   =
@@ -144,7 +144,7 @@ config.semantic.enable                   =
 config.semantic.variable                 =
 "對變數/欄位/參數進行語義著色。"
 config.semantic.annotation               =
-"對類型註解進行語義著色。"
+"對型別註解進行語義著色。"
 config.semantic.keyword                  =
 "對關鍵字/字面常數/運算子進行語義著色。只有當你的編輯器無法進行語法著色時才需要啟用此功能。"
 config.signatureHelp.enable              =
@@ -152,17 +152,17 @@ config.signatureHelp.enable              =
 config.hover.enable                      =
 "啟用懸浮提示。"
 config.hover.viewString                  =
-"懸浮提示查看字串內容（僅當字面常數包含跳脫字元時）。"
+"懸浮提示檢視字串內容（僅當字面常數包含跳脫字元時）。"
 config.hover.viewStringMax               =
-"懸浮提示查看字串內容時的最大長度。"
+"懸浮提示檢視字串內容時的最大長度。"
 config.hover.viewNumber                  =
-"懸浮提示查看數字內容（僅當字面常數不是十進制時）。"
+"懸浮提示檢視數字內容（僅當字面常數不是十進制時）。"
 config.hover.fieldInfer                  =
-"懸浮提示查看表時，會對表的每個欄位進行類型推測，當類型推測的用時累計達到該設定值（毫秒）時，將跳過後續欄位的類型推測。"
+"懸浮提示檢視表時，會對表的每個欄位進行型別推測，當型別推測的用時累計達到該設定值（毫秒）時，將跳過後續欄位的型別推測。"
 config.hover.previewFields               =
-"懸浮提示查看表時，限制表內欄位的最大預覽數量。"
+"懸浮提示檢視表時，限制表內欄位的最大預覽數量。"
 config.hover.enumsLimit                  =
-"當值對應多個類型時，限制類型的顯示數量。"
+"當值對應多個型別時，限制型別的顯示數量。"
 config.develop.enable                    =
 '開發者模式。請勿開啟，會影響效能。'
 config.develop.debuggerPort              =
@@ -172,7 +172,7 @@ config.develop.debuggerWait              =
 config.intelliSense.searchDepth          =
 '設定智慧感知的搜尋深度。增大該值可以增加準確度，但會降低效能。不同的工作區對該設定的容忍度差異較大，請自己調整為合適的值。'
 config.intelliSense.fastGlobal           =
-'在對全域變數進行補全，及查看 `_G` 的懸浮提示時進行最佳化。這會略微降低類型推測的準確度，但是對於大量使用全域變數的專案會有大幅的效能提升。'
+'在對全域變數進行補全，及檢視 `_G` 的懸浮提示時進行最佳化。這會略微降低型別推測的準確度，但是對於大量使用全域變數的專案會有大幅的效能提升。'
 config.window.statusBar                  =
 '在狀態欄顯示延伸模組狀態。'
 config.window.progressBar                =
@@ -180,15 +180,15 @@ config.window.progressBar                =
 config.hint.enable                       =
 '啟用內嵌提示。'
 config.hint.paramType                    =
-'在函式的參數位置提示類型。'
+'在函式的參數位置提示型別。'
 config.hint.setType                      =
-'在賦值操作位置提示類型。'
+'在賦值操作位置提示型別。'
 config.hint.paramName                    =
 '在函式呼叫處提示參數名。'
 config.hint.paramName.All                =
-'所有類型的參數均進行提示。'
+'所有型別的參數均進行提示。'
 config.hint.paramName.Literal            =
-'只有字面常數類型的參數進行提示。'
+'只有字面常數型別的參數進行提示。'
 config.hint.paramName.Disable            =
 '停用參數提示。'
 config.hint.arrayIndex                   =
@@ -196,7 +196,7 @@ config.hint.arrayIndex                   =
 config.hint.arrayIndex.Enable            =
 '所有的表中都提示陣列索引。'
 config.hint.arrayIndex.Auto              =
-'只有表大於3項，或者表是混合類型時才進行提示。'
+'只有表大於3項，或者表是混合型別時才進行提示。'
 config.hint.arrayIndex.Disable           =
 '停用陣列索引提示。'
 config.format.enable                     =
@@ -226,7 +226,7 @@ config.diagnostics['global-in-nil-env']     =
 config.diagnostics['unused-label']          =
 '未使用的標籤'
 config.diagnostics['unused-vararg']         =
-'未使用的不定參數'
+'未使用的不定引數'
 config.diagnostics['trailing-space']        =
 '後置空格'
 config.diagnostics['redefined-local']       =
@@ -236,9 +236,9 @@ config.diagnostics['newline-call']          =
 config.diagnostics['newfield-call']         =
 '在字面常數表中，2行程式碼之間缺少分隔符，在語法上被解析為了一次索引操作'
 config.diagnostics['redundant-parameter']   =
-'函式呼叫時，傳入了多餘的參數'
+'函式呼叫時，傳入了多餘的引數'
 config.diagnostics['ambiguity-1']           =
-'優先級歧義，如：`num or 0 + 1`，推測使用者的實際期望為 `(num or 0) + 1` '
+'優先級歧義，如： `num or 0 + 1` ，推測使用者的實際期望為 `(num or 0) + 1`'
 config.diagnostics['lowercase-global']      =
 '首字母小寫的全域變數定義'
 config.diagnostics['undefined-env-child']   =


### PR DESCRIPTION
1. 翻譯table.new、table.clear、WORKSPACE_NOT_ALLOWED、WORKSPACE_SCAN_TOO_MUCH、config.diagnostics.disableScheme、config.workspace.supportScheme。
2. 參考Visual Studio的繁體中文翻譯，將argument/parameter細分為引數/參數。
3. 調整標點符號的使用，刪除句號後面的空白
4. 在一對``的前後都加上空白
5. 微調部分細節。