### PR TITLE
繁體中文翻譯

### DIFF
--- a/doc/zh-tw/config.md
+++ b/doc/zh-tw/config.md
@@ -242,14 +242,14 @@ Array<string>
 
 # diagnostics.groupFileStatus
 
-Modify the diagnostic needed file status in a group.
+批量修改一個組中的檔案狀態。
 
-* Opened:  only diagnose opened files
-* Any:     diagnose all files
-* None:    disable this diagnostic
+* Opened:  只診斷打開的檔案
+* Any:     診斷所有檔案
+* None:    停用此診斷
 
-`Fallback` means that diagnostics in this group are controlled by `diagnostics.neededFileStatus` separately.
-Other settings will override individual settings without end of `!`.
+設定為 `Fallback` 意味著組中的診斷由 `diagnostics.neededFileStatus` 單獨設定。
+其他設定將覆蓋單獨設定，但是不會覆蓋以 `!` 結尾的設定。
 
 
 ## type
@@ -286,9 +286,9 @@ object<string, string>
 
 # diagnostics.groupSeverity
 
-Modify the diagnostic severity in a group.
-`Fallback` means that diagnostics in this group are controlled by `diagnostics.severity` separately.
-Other settings will override individual settings without end of `!`.
+批量修改一個組中的診斷等級。
+設定為 `Fallback` 意味著組中的診斷由 `diagnostics.severity` 單獨設定。
+其他設定將覆蓋單獨設定，但是不會覆蓋以 `!` 結尾的設定。
 
 
 ## type
@@ -370,11 +370,11 @@ string
 
 # diagnostics.neededFileStatus
 
-* Opened:  only diagnose opened files
-* Any:     diagnose all files
-* None:    disable this diagnostic
+* Opened:  只診斷打開的檔案
+* Any:     診斷所有檔案
+* None:    停用此診斷
 
-End with `!` means override the group setting `diagnostics.groupFileStatus`.
+以 `!` 結尾的設定優先順序高於組設定 `diagnostics.groupFileStatus`。
 
 
 ## type
@@ -449,9 +449,8 @@ object<string, string>
 
 # diagnostics.severity
 
-Modify the diagnostic severity.
-
-End with `!` means override the group setting `diagnostics.groupSeverity`.
+修改診斷等級。
+以 `!` 結尾的設定優先順序高於組設定 `diagnostics.groupSeverity`。
 
 
 ## type
@@ -544,7 +543,7 @@ integer
 
 # diagnostics.workspaceRate
 
-工作區診斷的執行速率（百分比）。降低該值會減少CPU佔用，但是也會降低工作區診斷的速度。你目前正在編輯的檔案的診斷總是全速完成，不受該選項影響。
+工作區診斷的執行速率（百分比）。降低該值會減少CPU使用率，但是也會降低工作區診斷的速度。你目前正在編輯的檔案的診斷總是全速完成，不受該選項影響。
 
 ## type
 
@@ -560,8 +559,8 @@ integer
 
 # format.defaultConfig
 
-The default format configuration. Has a lower priority than `.editorconfig` file in the workspace.
-Read [formatter docs](https://github.com/CppCXY/EmmyLuaCodeStyle/tree/master/docs) to learn usage.
+預設的格式化組態，優先順序低於工作區內的 `.editorconfig` 檔案。
+請查閱[格式化文件](https://github.com/CppCXY/EmmyLuaCodeStyle/tree/master/docs)了解用法。
 
 
 ## type
@@ -605,7 +604,7 @@ string
 ## enum
 
 * ``"Enable"``: 所有的表中都提示陣列索引。
-* ``"Auto"``: 只有表大於3項，或者表是混合型別時才進行提示。
+* ``"Auto"``: 只有表大於3項，或者表是混合類型時才進行提示。
 * ``"Disable"``: 停用陣列索引提示。
 
 ## default
@@ -616,7 +615,7 @@ string
 
 # hint.await
 
-If the called function is marked `---@async`, prompt `await` at the call.
+如果呼叫的函數被標記為了 `---@async`，則在呼叫處提示 `await`。
 
 ## type
 
@@ -658,8 +657,8 @@ string
 
 ## enum
 
-* ``"All"``: 所有型別的參數均進行提示。
-* ``"Literal"``: 只有字面常數型別的參數進行提示。
+* ``"All"``: 所有類型的參數均進行提示。
+* ``"Literal"``: 只有字面常數類型的參數進行提示。
 * ``"Disable"``: 停用參數提示。
 
 ## default
@@ -670,7 +669,7 @@ string
 
 # hint.paramType
 
-在函式的參數位置提示型別。
+在函式的參數位置提示類型。
 
 ## type
 
@@ -686,7 +685,7 @@ true
 
 # hint.setType
 
-在賦值操作位置提示型別。
+在賦值操作位置提示類型。
 
 ## type
 
@@ -718,7 +717,7 @@ true
 
 # hover.enumsLimit
 
-當值對應多個型別時，限制型別的顯示數量。
+當值對應多個類型時，限制類型的顯示數量。
 
 ## type
 
@@ -734,7 +733,7 @@ integer
 
 # hover.expandAlias
 
-Whether to expand the alias. For example, expands `---@alias myType boolean|number` appears as `boolean|number`, otherwise it appears as `myType'.
+是否展開別名。例如 `---@alias myType boolean|number` 展開後顯示為 `boolean|number`，否則顯示為 `myType'。
 
 
 ## type
@@ -815,7 +814,7 @@ integer
 
 # misc.parameters
 
-VSCode中啟動語言服務時的[命令列參數](https://github.com/sumneko/lua-language-server/wiki/Command-line)。
+VSCode中啟動語言伺服時的[命令列參數](https://github.com/sumneko/lua-language-server/wiki/Command-line)。
 
 ## type
 
@@ -897,7 +896,7 @@ string
 
 # runtime.meta
 
-Format of the directory name of the meta files.
+meta檔案的目錄名稱格式
 
 ## type
 
@@ -980,7 +979,7 @@ false
 
 # runtime.plugin
 
-延伸模組路徑，請查閲[文件](https://github.com/sumneko/lua-language-server/wiki/Plugin)瞭解用法。
+延伸模組路徑，請查閱[文件](https://github.com/sumneko/lua-language-server/wiki/Plugin)瞭解用法。
 
 ## type
 
@@ -1059,7 +1058,7 @@ string
 
 # semantic.annotation
 
-對型別註解進行語義著色。
+對類型註解進行語義著色。
 
 ## type
 
@@ -1139,7 +1138,7 @@ true
 
 # spell.dict
 
-Custom words for spell checking.
+拼寫檢查的自訂單詞。
 
 ## type
 
@@ -1155,7 +1154,7 @@ Array<string>
 
 # telemetry.enable
 
-啟用遙測，透過網路發送你的編輯器資訊與錯誤日誌。在[此處](https://github.com/sumneko/lua-language-server/wiki/%E9%9A%B1%E7%A7%81%E8%81%B2%E6%98%8E)閲讀我們的隱私聲明。
+啟用遙測，透過網路發送你的編輯器資訊與錯誤日誌。在[此處](https://github.com/sumneko/lua-language-server/wiki/%E9%9A%B1%E7%A7%81%E8%81%B2%E6%98%8E)閱讀我們的隱私聲明。
 
 
 ## type
@@ -1308,7 +1307,7 @@ integer
 
 # workspace.supportScheme
 
-為以下 `scheme` 的lua檔案提供語言服務。
+為以下 `scheme` 的lua檔案提供語言伺服。
 
 ## type
 

--- a/locale/en-us/script.lua
+++ b/locale/en-us/script.lua
@@ -724,7 +724,7 @@ function getTags(item) end
 ]=]
 LUADOC_DESC_FIELD =
 [=[
-Decalare a field in a class/table. This allows you to provide more in-depth
+Declare a field in a class/table. This allows you to provide more in-depth
 documentation for a table.
 
 ## Syntax
@@ -932,7 +932,7 @@ local unused = "hello world"
 ]=]
 LUADOC_DESC_MODULE =
 [=[
-Provides the semantics of `reqire`.
+Provides the semantics of `require`.
 
 ## Syntax
 `---@module <'module_name'>`

--- a/locale/pt-br/script.lua
+++ b/locale/pt-br/script.lua
@@ -724,7 +724,7 @@ function getTags(item) end
 ]=]
 LUADOC_DESC_FIELD = -- TODO: need translate!
 [=[
-Decalare a field in a class/table. This allows you to provide more in-depth
+Declare a field in a class/table. This allows you to provide more in-depth
 documentation for a table.
 
 ## Syntax
@@ -932,7 +932,7 @@ local unused = "hello world"
 ]=]
 LUADOC_DESC_MODULE = -- TODO: need translate!
 [=[
-Provides the semantics of `reqire`.
+Provides the semantics of `require`.
 
 ## Syntax
 `---@module <'module_name'>`

--- a/locale/zh-cn/script.lua
+++ b/locale/zh-cn/script.lua
@@ -724,7 +724,7 @@ function getTags(item) end
 ]=]
 LUADOC_DESC_FIELD = -- TODO: need translate!
 [=[
-Decalare a field in a class/table. This allows you to provide more in-depth
+Declare a field in a class/table. This allows you to provide more in-depth
 documentation for a table.
 
 ## Syntax
@@ -932,7 +932,7 @@ local unused = "hello world"
 ]=]
 LUADOC_DESC_MODULE = -- TODO: need translate!
 [=[
-Provides the semantics of `reqire`.
+Provides the semantics of `require`.
 
 ## Syntax
 `---@module <'module_name'>`

--- a/locale/zh-tw/meta.lua
+++ b/locale/zh-tw/meta.lua
@@ -31,13 +31,13 @@ collectgarbage      =
 '這個函式是垃圾回收器的一般介面。透過引數 opt 它提供了一組不同的功能。'
 
 dofile              =
-'打開該名字的檔案，並執行檔案中的 Lua 程式碼區塊。不帶引數呼叫時， `dofile` 執行標準輸入的內容（`stdin` ）。回傳該程式碼區塊的所有回傳值。對於有錯誤的情況， `dofile` 將錯誤回饋給呼叫者（即 `dofile` 沒有執行在保護模式下）。'
+'打開該名字的檔案，並執行檔案中的 Lua 程式碼區塊。不帶引數呼叫時， `dofile` 執行標準輸入的內容（`stdin`）。回傳該程式碼區塊的所有回傳值。對於有錯誤的情況， `dofile` 將錯誤回饋給呼叫者（即 `dofile` 沒有執行在保護模式下）。'
 
 error               =
 [[
 中止上一次保護函式呼叫，將錯誤對象 `message` 回傳。函式 `error` 永遠不會回傳。
 
-當 `message` 是一個字串時，通常 `error` 會把一些有關出錯位置的資訊附加在訊息的前頭。 `level` 引數指明了怎樣獲得出錯位置。
+當 `message` 是一個字串時，通常 `error` 會把一些有關出錯位置的資訊附加在訊息的開頭。 `level` 引數指明了怎樣獲得出錯位置。
 ]]
 
 _G                  =
@@ -47,7 +47,7 @@ getfenv             =
 '回傳給定函式的環境。 `f` 可以是一個Lua函式，也可是一個表示呼叫堆疊層級的數字。'
 
 getmetatable        =
-'如果 `object` 不包含元表，回傳 `nil` 。否則，如果在該物件的元表中有 `"__metatable"` 域時回傳其關聯值，沒有時回傳該對象的元表。'
+'如果 `object` 不包含中繼資料表，回傳 `nil` 。否則，如果在該物件的中繼資料表中有 `"__metatable"` 域時回傳其關聯值，沒有時回傳該對象的中繼資料表。'
 
 ipairs              =
 [[
@@ -134,25 +134,26 @@ setfenv             =
 
 setmetatable        =
 [[
-給指定表設定元表。（你不能在 Lua 中改變其它型別值的元表，那些只能在 C 裡做。）如果 `metatable` 是 `nil`，將指定表的元表移除。如果原來那張元表有 `"__metatable"` 域，擲回一個錯誤。
+為指定的表設定中繼資料表。（你不能在 Lua 中改變其它類型值的中繼資料表，那些只能在 C 裡做。）如果 `metatable` 是 `nil`，將指定的表的中繼資料表移除。如果原來那張中繼資料表有 `"__metatable"` 域，擲回一個錯誤。
 ]]
 
 tonumber            =
 [[
-如果呼叫的時候沒有 `base` ， `tonumber` 嘗試把引數轉換為一個數字。如果引數已經是一個數字，或是一個可以轉換為數字的字串， `tonumber` 就回傳這個數字，否則回傳 `nil`。
+如果呼叫的時候沒有 `base` ， `tonumber` 嘗試把引數轉換為一個數字。如果引數已經是一個數字，或是一個可以轉換為數字的字串， `tonumber` 就回傳這個數字，否則回傳 `fail`。
 
 字串的轉換結果可能是整數也可能是浮點數，這取決於 Lua 的轉換文法（參見 §3.1）。（字串可以有前置和後置的空格，可以帶符號。）
 ]]
 
 tostring            =
 [[
-可以接收任何型別，它將其轉換為人可閲讀的字串形式。浮點數總被轉換為浮點數的表現形式（小數點形式或是指數形式）。（如果想完全控制數字如何被轉換，可以使用 $string.format 。）
-如果 `v` 有 `"__tostring"` 域的元表， `tostring` 會以 `v` 為引數呼叫它。並用它的結果作為回傳值。
+可以接收任何類型，它將其轉換為人可閱讀的字串形式。浮點數總被轉換為浮點數的表現形式（小數點形式或是指數形式）。
+如果 `v` 有 `"__tostring"` 域的中繼資料表， `tostring` 會以 `v` 為引數呼叫它。並用它的結果作為回傳值。
+如果想完全控制數字如何被轉換，可以使用 $string.format 。
 ]]
 
 type                =
 [[
-將引數的型別編碼為一個字串回傳。 函式可能的回傳值有 `"nil"` （一個字串，而不是 `nil` 值）、 `"number"` 、 `"string"` 、 `"boolean"` 、 `"table"` 、 `"function"` 、 `"thread"` 和 `"userdata"`。
+將引數的類型編碼為一個字串回傳。 函式可能的回傳值有 `"nil"` （一個字串，而不是 `nil` 值）、 `"number"` 、 `"string"` 、 `"boolean"` 、 `"table"` 、 `"function"` 、 `"thread"` 和 `"userdata"`。
 ]]
 
 _VERSION            =
@@ -194,7 +195,7 @@ assert(bit32.bnot(x) ==
 bit32.bor           =
 '回傳參數按位元或的結果。'
 bit32.btest         =
-'參數按位元與的結果不為0時，回傳 `true` 。'
+'參數按位元與的結果不為 `0` 時，回傳 `true` 。'
 bit32.bxor          =
 '回傳參數按位元互斥或的結果。'
 bit32.extract       =
@@ -227,7 +228,7 @@ assert(bit32.lshift(b, disp) ==
 coroutine                     =
 ''
 coroutine.create              =
-'建立一個主體函式為 `f` 的新共常式。 f 必須是一個 Lua 的函式。回傳這個新共常式，它是一個型別為 `"thread"` 的物件。'
+'建立一個主體函式為 `f` 的新共常式。 f 必須是一個 Lua 的函式。回傳這個新共常式，它是一個類型為 `"thread"` 的物件。'
 coroutine.isyieldable         =
 '如果正在執行的共常式可以讓出，則回傳真。'
 coroutine.isyieldable['>5.4'] =
@@ -261,7 +262,7 @@ debug.debug               =
 debug.getfenv             =
 '回傳物件 `o` 的環境。'
 debug.gethook             =
-'回傳三個表示執行緒攔截設定的值：目前攔截函式，目前鉤子遮罩，目前鉤子計數。'
+'回傳三個表示執行緒攔截設定的值：目前攔截函式，目前攔截遮罩，目前攔截計數。'
 debug.getinfo             =
 '回傳關於一個函式資訊的表。'
 debug.getlocal['<5.1']    =
@@ -269,7 +270,7 @@ debug.getlocal['<5.1']    =
 debug.getlocal['>5.2']    =
 '回傳在堆疊的 `f` 層處函式的索引為 `index` 的區域變數的名字和值。'
 debug.getmetatable        =
-'回傳給定 `value` 的元表。'
+'回傳給定 `value` 的中繼資料表。'
 debug.getregistry         =
 '回傳註冊表。'
 debug.getupvalue          =
@@ -289,11 +290,11 @@ debug.setcstacklimit      =
 debug.setfenv             =
 '將 `table` 設定為 `object` 的環境。'
 debug.sethook             =
-'將一個函式作為攔截函式設入。'
+'將一個函式設定為攔截函式。'
 debug.setlocal            =
 '將 `value` 賦給 堆疊上第 `level` 層函式的第 `local` 個區域變數。'
 debug.setmetatable        =
-'將 `value` 的元表設為 `table` （可以是 `nil` ）。'
+'將 `value` 的中繼資料表設為 `table` （可以是 `nil` ）。'
 debug.setupvalue          =
 '將 `value` 設為函式 `f` 的第 `up` 個上值。'
 debug.setuservalue['<5.3']=
@@ -327,11 +328,11 @@ infowhat.L                =
 '`activelines`'
 
 hookmask.c                =
-'每當 Lua 呼叫一個函式時，呼叫鉤子。'
+'每當 Lua 呼叫一個函式時，呼叫攔截。'
 hookmask.r                =
-'每當 Lua 從一個函式內回傳時，呼叫鉤子。'
+'每當 Lua 從一個函式內回傳時，呼叫攔截。'
 hookmask.l                =
-'每當 Lua 進入新的一行時，呼叫鉤子。'
+'每當 Lua 進入新的一行時，呼叫攔截。'
 
 file                        =
 ''
@@ -362,9 +363,9 @@ readmode.n                  =
 readmode.a                  =
 '從目前位置開始讀取整個檔案。'
 readmode.l                  =
-'讀取一行並忽略行結束標記。'
+'讀取一行並忽略行尾標記。'
 readmode.L                  =
-'讀取一行並保留行結束標記。'
+'讀取一行並保留行尾標記。'
 
 seekwhence.set              =
 '基點為 0 （檔案開頭）。'
@@ -408,7 +409,7 @@ io.open                    =
 io.output                  =
 '設定 `file` 為預設輸出檔案。'
 io.popen                   =
-'用一個分離程序開啟程式 `prog` 。'
+'用一個分離處理程序開啟程式 `prog` 。'
 io.read                    =
 '讀取檔案 `file` ，指定的格式決定了要讀取什麼。'
 io.tmpfile                 =
@@ -545,13 +546,13 @@ math.ult                    =
 os                          =
 ''
 os.clock                    =
-'回傳程式使用的按秒計 CPU 時間的近似值。'
+'回傳程式使用的 CPU 時間的近似值，單位為秒。'
 os.date                     =
 '回傳一個包含日期及時刻的字串或表。格式化方法取決於所給字串 `format` 。'
 os.difftime                 =
 '回傳以秒計算的時刻 `t1` 到 `t2` 的差值。'
 os.execute                  =
-'呼叫系統直譯器執行 `command` 。'
+'呼叫作業系統殼層執行 `command` 。'
 os.exit['<5.1']             =
 '呼叫 C 函式 `exit` 終止宿主程式。'
 os.exit['>5.2']             =
@@ -586,7 +587,7 @@ osdate.wday                 =
 osdate.yday                 =
 '該年的第幾天，範圍為1-366'
 osdate.isdst                =
-'夏令時間，一個布林值'
+'是否為夏令時間，一個布林值'
 
 package                     =
 ''
@@ -597,7 +598,7 @@ require['>5.4']             =
 '載入一個模組，回傳該模組的回傳值（ `nil` 時為 `true` ）與搜尋器回傳的載入資料。預設搜尋器的載入資料指示了載入位置，對於檔案來説就是檔案路徑。'
 
 package.config              =
-'一個描述有一些為包管理準備的編譯時期組態訊息的串。'
+'一個描述一些為包管理準備的編譯時期組態的字串。'
 package.cpath               =
 '這個路徑被 `require` 在 C 載入器中做搜尋時用到。'
 package.loaded              =
@@ -615,7 +616,7 @@ package.searchers           =
 package.searchpath          =
 '在指定 `path` 中搜尋指定的 `name` 。'
 package.seeall              =
-'給 `module` 設定一個元表，該元表的 `__index` 域為全域環境，這樣模組便會繼承全域環境的值。可作為 `module` 函式的選項。'
+'給 `module` 設定一個中繼資料表，該中繼資料表的 `__index` 域為全域環境，這樣模組便會繼承全域環境的值。可作為 `module` 函式的選項。'
 
 string                      =
 ''
@@ -715,7 +716,7 @@ table.clear                 =
 ```lua
     require("table.clear")
 ```
-請注意，此函式適用於非常特殊的情況。在大多數情況下，最好用新表替換（通常是單個）連結，並讓垃圾回收完成工作。
+請注意，此函式適用於非常特殊的情況。在大多數情況下，最好用新表替換（通常是單個）連結，並讓垃圾回收自行處理。
 ]]
 
 utf8                        =

--- a/locale/zh-tw/script.lua
+++ b/locale/zh-tw/script.lua
@@ -79,11 +79,11 @@ DIAG_UNBALANCED_ASSIGNMENTS =
 DIAG_REQUIRE_LIKE       =
 '你可以在設定中將 `{}` 視為 `require`。'
 DIAG_COSE_NON_OBJECT    =
-'無法 close 此型別的值。（除非給此型別設定 `__close` 元方法）'
+'無法 close 此類型的值。（除非給此類型設定 `__close` 元方法）'
 DIAG_COUNT_DOWN_LOOP    =
 '你的意思是 `{}` 嗎？'
 DIAG_UNKNOWN            =
-'無法推測出型別。'
+'無法推測出類型。'
 DIAG_DEPRECATED         =
 '已廢棄。'
 DIAG_DIFFERENT_REQUIRES =
@@ -111,23 +111,23 @@ DIAG_DUPLICATE_DOC_PARAM              =
 DIAG_UNDEFINED_DOC_CLASS              =
 '未定義的類別 `{}`。'
 DIAG_UNDEFINED_DOC_NAME               =
-'未定義的型別或別名 `{}`。'
+'未定義的類型或別名 `{}`。'
 DIAG_UNDEFINED_DOC_PARAM              =
 '指向了未定義的參數 `{}`。'
 DIAG_UNKNOWN_DIAG_CODE                =
 '未知的診斷代碼 `{}`。'
-DIAG_CAST_LOCAL_TYPE                  = -- TODO: need translate!
-'This variable has explicitly defined as `{def}`. Cannot convert its type to `{ref}`.'
-DIAG_CAST_FIELD_TYPE                  = -- TODO: need translate!
-'This field has explicitly defined as `{def}`. Cannot convert its type to `{ref}`.'
-DIAG_ASSIGN_TYPE_MISMATCH             = -- TODO: need translate!
-'Cannot assign `{ref}` to `{def}`.'
-DIAG_PARAM_TYPE_MISMATCH              = -- TODO: need translate!
-'Cannot assign `{ref}` to parameter `{def}`.'
-DIAG_UNKNOWN_CAST_VARIABLE            = -- TODO: need translate!
-'Unknown type conversion variable `{}`.'
-DIAG_CAST_TYPE_MISMATCH               = -- TODO: need translate!
-'Cannot convert `{ref}` to `{def}`。'
+DIAG_CAST_LOCAL_TYPE                  =
+'已顯式定義變數的類型為 `{def}`，不能再將其類型轉換為 `{ref}`。'
+DIAG_CAST_FIELD_TYPE                  =
+'已顯式定義欄位的類型為 `{def}`，不能再將其類型轉換為 `{ref}`。'
+DIAG_ASSIGN_TYPE_MISMATCH             =
+'不能將 `{ref}` 賦值給 `{def}`。'
+DIAG_PARAM_TYPE_MISMATCH              =
+'不能將 `{ref}` 賦值給參數 `{def}`.'
+DIAG_UNKNOWN_CAST_VARIABLE            =
+'未知的類型轉換變數 `{}`.'
+DIAG_CAST_TYPE_MISMATCH               =
+'不能將 `{ref}` 轉換為 `{def}`。'
 
 MWS_NOT_SUPPORT         =
 '{} 目前還不支援多工作目錄，我可能需要重新啟動才能支援新的工作目錄...'
@@ -155,7 +155,7 @@ WORKSPACE_DIAGNOSTIC      =
 WORKSPACE_SKIP_HUGE_FILE  =
 '出於效能考慮，已停止對此檔案解析：{}'
 WORKSPACE_NOT_ALLOWED     =
-'你的工作目錄被設定為了 `{}` ，Lua語言服務拒絕載入此目錄，請檢查你的設定檔。[了解更多](https://github.com/sumneko/lua-language-server/wiki/Why-scanning-home-folder)'
+'你的工作目錄被設定為了 `{}` ，Lua語言伺服拒絕載入此目錄，請檢查你的設定檔。[了解更多](https://github.com/sumneko/lua-language-server/wiki/Why-scanning-home-folder)'
 WORKSPACE_SCAN_TOO_MUCH   =
 '已掃描了超過 {} 個檔案，目前掃描的目錄為 `{}`，請確認設定檔是否正確。'
 
@@ -264,7 +264,7 @@ PARSER_LUADOC_MISS_SYMBOL               =
 PARSER_LUADOC_MISS_ARG_NAME             =
 '缺少參數名稱。'
 PARSER_LUADOC_MISS_TYPE_NAME            =
-'缺少型別名。'
+'缺少類型名。'
 PARSER_LUADOC_MISS_ALIAS_NAME           =
 '缺少別名。'
 PARSER_LUADOC_MISS_ALIAS_EXTENDS        =
@@ -272,21 +272,21 @@ PARSER_LUADOC_MISS_ALIAS_EXTENDS        =
 PARSER_LUADOC_MISS_PARAM_NAME           =
 '缺少要指向的參數名稱。'
 PARSER_LUADOC_MISS_PARAM_EXTENDS        =
-'缺少參數的型別定義。'
+'缺少參數的類型定義。'
 PARSER_LUADOC_MISS_FIELD_NAME           =
 '缺少欄位名稱。'
 PARSER_LUADOC_MISS_FIELD_EXTENDS        =
-'缺少欄位的型別定義。'
+'缺少欄位的類型定義。'
 PARSER_LUADOC_MISS_GENERIC_NAME         =
 '缺少泛型名稱。'
 PARSER_LUADOC_MISS_GENERIC_EXTENDS_NAME =
 '缺少泛型要繼承的類別名稱。'
 PARSER_LUADOC_MISS_VARARG_TYPE          =
-'缺少可變引數的型別定義。'
+'缺少可變引數的類型定義。'
 PARSER_LUADOC_MISS_FUN_AFTER_OVERLOAD   =
 '缺少關鍵字 `fun` 。'
 PARSER_LUADOC_MISS_CATE_NAME            =
-'缺少文件型別名稱。'
+'缺少文件類型名稱。'
 PARSER_LUADOC_MISS_DIAG_MODE            =
 '缺少診斷模式。'
 PARSER_LUADOC_ERROR_DIAG_MODE           =
@@ -334,7 +334,7 @@ HOVER_USE_LUA_PATH      =
 HOVER_EXTENDS           =
 '展開為 {}'
 HOVER_TABLE_TIME_UP     =
-'出於效能考慮，已停用了部分型別推斷。'
+'出於效能考慮，已停用了部分類型推斷。'
 HOVER_WS_LOADING        =
 '正在載入工作目錄：{} / {}'
 HOVER_AWAIT_TOOLTIP     =
@@ -381,7 +381,7 @@ ACTION_ADD_END          =
 ACTION_FIX_COMMENT_PREFIX =
 '改為 `--` 。'
 ACTION_FIX_NONSTANDARD_SYMBOL =
-'改為 `{symbol}`'
+'改為 `{symbol}`。'
 ACTION_RUNTIME_UNICODE_NAME =
 '允許使用 Unicode 字元。'
 ACTION_SWAP_PARAMS      =
@@ -396,8 +396,8 @@ ACTION_DISABLE_DIAG_FILE=
 '在此檔案停用診斷 ({})。'
 ACTION_MARK_ASYNC       =
 '將目前函式標記為非同步。'
-ACTION_ADD_DICT         = -- TODO: need translate!
-'Add \'{}\' to workspace dict'
+ACTION_ADD_DICT         =
+'添加 \'{}\' 到工作區字典'
 
 COMMAND_DISABLE_DIAG       =
 '停用診斷'
@@ -417,8 +417,8 @@ COMMAND_JSON_TO_LUA        =
 'JSON 轉 Lua'
 COMMAND_JSON_TO_LUA_FAILED =
 'JSON 轉 Lua 失敗：{}'
-COMMAND_ADD_DICT           = -- TODO: need translate!
-'Add Word to dictionary'
+COMMAND_ADD_DICT           =
+'添加單字到字典裡'
 
 COMPLETION_IMPORT_FROM           =
 '從 {} 中匯入'
@@ -428,7 +428,7 @@ COMPLETION_ASK_AUTO_REQUIRE      =
 '在檔案頂部添加程式碼 require 此檔案？'
 
 DEBUG_MEMORY_LEAK       =
-'{} 很抱歉發生了嚴重的記憶體漏失，語言服務即將重新啟動。'
+'{} 很抱歉發生了嚴重的記憶體漏失，語言伺服即將重新啟動。'
 DEBUG_RESTART_NOW       =
 '立即重新啟動'
 
@@ -494,7 +494,7 @@ WINDOW_APPLY_SETTING             =
 WINDOW_CHECK_SEMANTIC            =
 '如果你正在使用市場中的顏色主題，你可能需要同時修改 `editor.semanticHighlighting.enabled` 選項為 `true` 才會使語義著色生效。'
 WINDOW_TELEMETRY_HINT            =
-'請允許發送匿名的使用資料與錯誤報告，幫助我們進一步完善此延伸模組。在[此處](https://github.com/sumneko/lua-language-server/wiki/%E9%9A%B1%E7%A7%81%E8%81%B2%E6%98%8E)閲讀我們的隱私聲明。'
+'請允許發送匿名的使用資料與錯誤報告，幫助我們進一步完善此延伸模組。在[此處](https://github.com/sumneko/lua-language-server/wiki/%E9%9A%B1%E7%A7%81%E8%81%B2%E6%98%8E)閱讀我們的隱私聲明。'
 WINDOW_TELEMETRY_ENABLE          =
 '允許'
 WINDOW_TELEMETRY_DISABLE         =
@@ -559,51 +559,51 @@ CLI_CHECK_SUCCESS =
 CLI_CHECK_RESULTS =
 '診斷完成，共有 {} 個問題，請查看 {}'
 
-LUADOC_DESC_CLASS = -- TODO: need translate!
+LUADOC_DESC_CLASS =
 [=[
-Defines a class/table structure
-## Syntax
+定義一個類別/表結構
+## 語法
 `---@class <name> [: <parent>[, <parent>]...]`
-## Usage
+## 用法
 ```
 ---@class Manager: Person, Human
 Manager = {}
 ```
 ---
-[View Wiki](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#class)
+[檢視文件](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#class)
 ]=]
-LUADOC_DESC_TYPE = -- TODO: need translate!
+LUADOC_DESC_TYPE =
 [=[
-Specify the type of a certain variable
+指定一個變數的類型
 
-Default types: `nil`, `any`, `boolean`, `string`, `number`, `integer`,
-`function`, `table`, `thread`, `userdata`, `lightuserdata`
+預設類型： `nil` 、 `any` 、 `boolean` 、 `string` 、 `number` 、 `integer`、
+`function` 、 `table` 、 `thread` 、 `userdata` 、 `lightuserdata`
 
-(Custom types can be provided using `@alias`)
+（可以使用 `@alias` 提供自訂類型）
 
-## Syntax
+## 語法
 `---@type <type>[| [type]...`
 
-## Usage
-### General
+## 用法
+### 一般
 ```
 ---@type nil|table|myClass
 local Example = nil
 ```
 
-### Arrays
+### 陣列
 ```
 ---@type number[]
 local phoneNumbers = {}
 ```
 
-### Enums
+### 列舉
 ```
 ---@type "red"|"green"|"blue"
 local color = ""
 ```
 
-### Tables
+### 表
 ```
 ---@type table<string, boolean>
 local settings = {
@@ -615,21 +615,21 @@ local settings = {
 local x --x[""] is true
 ```
 
-### Functions
+### 函式
 ```
 ---@type fun(mode?: "r"|"w"): string
 local myFunction
 ```
 ---
-[View Wiki](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#types-and-type)
+[檢視文件](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#types-and-type)
 ]=]
-LUADOC_DESC_ALIAS = -- TODO: need translate!
+LUADOC_DESC_ALIAS =
 [=[
-Create your own custom type that can be used with `@param`, `@type`, etc.
+新增你的自訂類型，可以與 `@param`、`@type` 等一起使用。
 
-## Syntax
+## 語法
 `---@alias <name> <type> [description]`\
-or
+或
 ```
 ---@alias <name>
 ---| 'value' [# comment]
@@ -637,7 +637,7 @@ or
 ...
 ```
 
-## Usage
+## 用法
 ### Expand to other type
 ```
 ---@alias filepath string Path to a file
@@ -646,7 +646,7 @@ or
 function find(path, pattern) end
 ```
 
-### Enums
+### 列舉
 ```
 ---@alias font-style
 ---| '"underlined"' # Underline the text
@@ -657,17 +657,17 @@ function find(path, pattern) end
 function setFontStyle(style) end
 ```
 ---
-[View Wiki](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#alias)
+[檢視文件](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#alias)
 ]=]
-LUADOC_DESC_PARAM = -- TODO: need translate!
+LUADOC_DESC_PARAM =
 [=[
-Declare a function parameter
+宣告一個函式參數
 
-## Syntax
+## 語法
 `@param <name>[?] <type> [comment]`
 
-## Usage
-### General
+## 用法
+### 一般
 ```
 ---@param url string The url to request
 ---@param headers? table<string, string> HTTP headers to send
@@ -675,26 +675,26 @@ Declare a function parameter
 function get(url, headers, timeout) end
 ```
 
-### Variable Arguments
+### 可變引數
 ```
 ---@param base string The base to concat to
 ---@param ... string The values to concat
 function concat(base, ...) end
 ```
 ---
-[View Wiki](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#param)
+[檢視文件](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#param)
 ]=]
-LUADOC_DESC_RETURN = -- TODO: need translate!
+LUADOC_DESC_RETURN =
 [=[
-Declare a return value
+宣告一個回傳值
 
-## Syntax
+## 語法
 `@return <type> [name] [description]`\
-or\
+或\
 `@return <type> [# description]`
 
-## Usage
-### General
+## 用法
+### 一般
 ```
 ---@return number
 ---@return number # The green component
@@ -702,35 +702,34 @@ or\
 function hexToRGB(hex) end
 ```
 
-### Type & name only
+### 僅限類型和名稱
 ```
 ---@return number x, number y
 function getCoords() end
 ```
 
-### Type only
+### 僅限類型
 ```
 ---@return string, string
 function getFirstLast() end
 ```
 
-### Return variable values
+### 回傳變數值
 ```
 ---@return string ... The tags of the item
 function getTags(item) end
 ```
 ---
-[View Wiki](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#return)
+[檢視文件](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#return)
 ]=]
-LUADOC_DESC_FIELD = -- TODO: need translate!
+LUADOC_DESC_FIELD =
 [=[
-Decalare a field in a class/table. This allows you to provide more in-depth
-documentation for a table.
+在類別/表中宣告一個欄位。 這使你可以為表提供更深入詳細的文件。
 
-## Syntax
+## 語法
 `---@field <name> <type> [description]`
 
-## Usage
+## 用法
 ```
 ---@class HTTP_RESPONSE
 ---@field status HTTP_STATUS
@@ -750,18 +749,17 @@ response = get("localhost")
 statusCode = response.status.code
 ```
 ---
-[View Wiki](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#field)
+[檢視文件](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#field)
 ]=]
-LUADOC_DESC_GENERIC = -- TODO: need translate!
+LUADOC_DESC_GENERIC =
 [=[
-Simulates generics. Generics can allow types to be re-used as they help define
-a "generic shape" that can be used with different types.
+模擬泛型。 泛型可以允許類型被重用，因為它們有助於定義可用於不同類型的"通用形狀"。
 
-## Syntax
+## 語法
 `---@generic <name> [:parent_type] [, <name> [:parent_type]]`
 
-## Usage
-### General
+## 用法
+### 一般
 ```
 ---@generic T
 ---@param value T The value to return
@@ -784,7 +782,7 @@ b = echo(true)
 -- each allowed type
 ```
 
-### Capture name of generic type
+### 捕獲泛型類型的名稱
 ```
 ---@class Foo
 local Foo = {}
@@ -798,7 +796,7 @@ function Generic(name) end
 local v = Generic("Foo") -- v is an object of Foo
 ```
 
-### How Lua tables use generics
+### Lua 表如何使用泛型
 ```
 ---@class table<K, V>: { [K]: V }
 
@@ -807,137 +805,135 @@ local v = Generic("Foo") -- v is an object of Foo
 -- we give for key (K) or value (V)
 ```
 ---
-[View Wiki](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#generics-and-generic)
+[檢視文件](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#generics-and-generic)
 ]=]
-LUADOC_DESC_VARARG = -- TODO: need translate!
+LUADOC_DESC_VARARG =
 [=[
-Primarily for legacy support for EmmyLua annotations. `@vararg` does not
-provide typing or allow descriptions.
+主要用於對 EmmyLua 註解的向下支援。 `@vararg` 不提供輸入或允許描述。
 
-**You should instead use `@param` when documenting parameters (variable or not).**
+**在記錄參數（變數或非變數）時，您應該改用 `@param`。**
 
-## Syntax
+## 語法
 `@vararg <type>`
 
-## Usage
+## 用法
 ```
 ---Concat strings together
 ---@vararg string
 function concat(...) end
 ```
 ---
-[View Wiki](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#vararg)
+[檢視文件](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#vararg)
 ]=]
-LUADOC_DESC_OVERLOAD = -- TODO: need translate!
+LUADOC_DESC_OVERLOAD =
 [=[
-Allows defining of multiple function signatures.
+允許定義多個函數簽章。
 
-## Syntax
+## 語法
 `---@overload fun(<name>[: <type>] [, <name>[: <type>]]...)[: <type>[, <type>]...]`
 
-## Usage
+## 用法
 ```
 ---@overload fun(t: table, value: any): number
 function table.insert(t, position, value) end
 ```
 ---
-[View Wiki](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#overload)
+[檢視文件](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#overload)
 ]=]
-LUADOC_DESC_DEPRECATED = -- TODO: need translate!
+LUADOC_DESC_DEPRECATED =
 [=[
-Marks a function as deprecated. This results in any deprecated function calls
-being ~~struck through~~.
+將函式標記為已棄用。 這會導致任何不推薦使用的函式呼叫被 ~~擊穿~~。
 
-## Syntax
+## 語法
 `---@deprecated`
 
 ---
-[View Wiki](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#deprecated)
+[檢視文件](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#deprecated)
 ]=]
-LUADOC_DESC_META = -- TODO: need translate!
+LUADOC_DESC_META =
 [=[
-Indicates that this is a meta file and should be used for definitions and intellisense only.
+表示這是一個中繼檔案，應僅用於定義和智慧感知。
 
-There are 3 main distinctions to note with meta files:
-1. There won't be any context-based intellisense in a meta file
-2. Hovering a `require` filepath in a meta file shows `[meta]` instead of an absolute path
-3. The `Find Reference` function will ignore meta files
+中繼檔案有 3 個主要區別需要注意：
+1. 中繼檔案中不會有任何基於上下文的智慧感知
+2. 將 `require` 檔案路徑懸停在中繼檔案中會顯示 `[meta]` 而不是絕對路徑
+3. `Find Reference` 功能會忽略中繼檔案
 
-## Syntax
+## 語法
 `---@meta`
 
 ---
-[View Wiki](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#meta)
+[檢視文件](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#meta)
 ]=]
-LUADOC_DESC_VERSION = -- TODO: need translate!
+LUADOC_DESC_VERSION =
 [=[
-Specifies Lua versions that this function is exclusive to.
+指定此函式獨有的 Lua 版本。
 
-Lua versions: `5.1`, `5.2`, `5.3`, `5.4`, `JIT`.
+Lua 版本：`5.1` 、 `5.2` 、 `5.3` 、 `5.4` 、 `JIT`。
 
-Requires configuring the `Diagnostics: Needed File Status` setting.
+需要 `Diagnostics: Needed File Status` 設定。
 
-## Syntax
+## 語法
 `---@version <version>[, <version>]...`
 
-## Usage
-### General
+## 用法
+### 一般
 ```
 ---@version JIT
 function onlyWorksInJIT() end
 ```
-### Specify multiple versions
+### 指定多個版本
 ```
 ---@version <5.2,JIT
 function oldLuaOnly() end
 ```
 ---
-[View Wiki](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#version)
+[檢視文件](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#version)
 ]=]
-LUADOC_DESC_SEE = -- TODO: need translate!
+LUADOC_DESC_SEE =
 [=[
-Define something that can be viewed for more information
+定義可以檢視以獲取更多資訊的內容
 
 ## Syntax
 `---@see <text>`
 
 ---
-[View Wiki](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#see)
+[檢視文件](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#see)
 ]=]
-LUADOC_DESC_DIAGNOSTIC = -- TODO: need translate!
+LUADOC_DESC_DIAGNOSTIC =
 [=[
-Enable/disable diagnostics for error/warnings/etc.
+啟用/停用診斷錯誤與警告等。
 
-Actions: `disable`, `enable`, `disable-line`, `disable-next-line`
+操作：`disable` 、 `enable` 、 `disable-line` 、 `disable-next-line`
 
-[Names](https://github.com/sumneko/lua-language-server/blob/cbb6e6224094c4eb874ea192c5f85a6cba099588/script/proto/define.lua#L54)
+[名稱](https://github.com/sumneko/lua-language-server/blob/cbb6e6224094c4eb874ea192c5f85a6cba099588/script/proto/define.lua#L54)
 
-## Syntax
+## 語法
 `---@diagnostic <action>[: <name>]`
 
-## Usage
-### Disable next line
+## 用法
+### 停用下一行
 ```
 ---@diagnostic disable-next-line: undefined-global
 ```
 
-### Manually toggle
+### 手動切換
 ```
 ---@diagnostic disable: unused-local
 local unused = "hello world"
 ---@diagnostic enable: unused-local
 ```
 ---
-[View Wiki](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#diagnostic)
+[檢視文件](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#diagnostic)
 ]=]
-LUADOC_DESC_MODULE = -- TODO: need translate!
+LUADOC_DESC_MODULE =
 [=[
-Provides the semantics of `reqire`.
+提供 `require` 的語義。
 
-## Syntax
+## 語法
 `---@module <'module_name'>`
 
-## Usage
+## 用法
 ```
 ---@module 'string.utils'
 local stringUtils
@@ -945,41 +941,40 @@ local stringUtils
 local module = require('string.utils')
 ```
 ---
-[View Wiki](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#module)
+[檢視文件](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#module)
 ]=]
-LUADOC_DESC_ASYNC = -- TODO: need translate!
+LUADOC_DESC_ASYNC =
 [=[
-Marks a function as asynchronous.
+將函式標記為非同步
 
-## Syntax
+## 語法
 `---@async`
 
 ---
-[View Wiki](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#async)
+[檢視文件](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#async)
 ]=]
-LUADOC_DESC_NODISCARD = -- TODO: need translate!
+LUADOC_DESC_NODISCARD =
 [=[
-Prevents this function's return values from being discarded/ignored.
-This will raise the `discard-returns` warning should the return values
-be ignored.
+防止此函式的回傳值被丟棄/忽略。
+如果忽略回傳值，這將引發 `discard-returns` 警告。
 
-## Syntax
+## 語法
 `---@nodiscard`
 
 ---
-[View Wiki](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#nodiscard)
+[檢視文件](https://github.com/sumneko/lua-language-server/wiki/EmmyLua-Annotations#nodiscard)
 ]=]
-LUADOC_DESC_CAST = -- TODO: need translate!
+LUADOC_DESC_CAST =
 [=[
-Allows type casting (type conversion).
+允許類型轉換。
 
-⚠️ **Not Finalized**
+⚠️ **不是最終定案**
 
-## Syntax
+## 語法
 `@cast <variable> <[+|-]type>[, <[+|-]type>]...`
 
-## Usage
-### Overwrite type
+## 用法
+### 覆蓋類型
 ```
 ---@type integer
 local x --> integer
@@ -987,7 +982,7 @@ local x --> integer
 ---@cast x string
 print(x) --> string
 ```
-### Add Type
+### 增加類型
 ```
 ---@type string
 local x --> string
@@ -995,7 +990,7 @@ local x --> string
 ---@cast x +boolean, +number
 print(x) --> string|boolean|number
 ```
-### Remove Type
+### 移除類型
 ```
 ---@type string|table
 local x --> string|table
@@ -1004,5 +999,5 @@ local x --> string|table
 print(x) --> table
 ```
 ---
-[View Proposal](https://github.com/sumneko/lua-language-server/issues/1030)
+[檢視提議](https://github.com/sumneko/lua-language-server/issues/1030)
 ]=]

--- a/locale/zh-tw/setting.lua
+++ b/locale/zh-tw/setting.lua
@@ -12,7 +12,7 @@ config.runtime.path               =
 config.runtime.pathStrict         =
 '啟用後 `runtime.path` 將只搜尋第一層目錄，見 `runtime.path` 的説明。'
 config.runtime.special            =
-[[將自訂全域變數視為一些特殊的內建變數，語言服務將提供特殊的支援。
+[[將自訂全域變數視為一些特殊的內建變數，語言伺服將提供特殊的支援。
 下面這個例子表示將 `include` 視為 `require` 。
 ```json
 "Lua.runtime.special" : {
@@ -25,60 +25,59 @@ config.runtime.unicodeName        =
 config.runtime.nonstandardSymbol  =
 "支援非標準的符號。請務必確認你的執行環境支援這些符號。"
 config.runtime.plugin             =
-"延伸模組路徑，請查閲[文件](https://github.com/sumneko/lua-language-server/wiki/Plugin)瞭解用法。"
+"延伸模組路徑，請查閱[文件](https://github.com/sumneko/lua-language-server/wiki/Plugin)瞭解用法。"
 config.runtime.fileEncoding       =
-"檔案編碼，`ansi` 選項只在 `Windows` 平台下有效。"
+"檔案編碼，選項 `ansi` 只在 `Windows` 平台下有效。"
 config.runtime.builtin            =
 [[
-調整內建庫的啟用狀態，你可以根據實際執行環境停用不存在的庫（或重新定義）。
+調整內建庫的啟用狀態，你可以根據實際執行環境停用（或重新定義）不存在的庫。
 
 * `default`: 表示庫會根據執行版本啟用或停用
 * `enable`: 總是啟用
 * `disable`: 總是停用
 ]]
-config.runtime.meta               = -- TODO: need translate!
-'Format of the directory name of the meta files.'
+config.runtime.meta               =
+'meta檔案的目錄名稱格式'
 config.diagnostics.enable         =
 "啟用診斷。"
 config.diagnostics.disable        =
 "停用的診斷（使用浮框括號內的程式碼）。"
 config.diagnostics.globals        =
 "已定義的全域變數。"
-config.diagnostics.severity       = -- TODO: need translate!
+config.diagnostics.severity       =
 [[
-Modify the diagnostic severity.
-
-End with `!` means override the group setting `diagnostics.groupSeverity`.
+修改診斷等級。
+以 `!` 結尾的設定優先順序高於組設定 `diagnostics.groupSeverity`。
 ]]
-config.diagnostics.neededFileStatus = -- TODO: need translate!
+config.diagnostics.neededFileStatus =
 [[
-* Opened:  only diagnose opened files
-* Any:     diagnose all files
-* None:    disable this diagnostic
+* Opened:  只診斷打開的檔案
+* Any:     診斷所有檔案
+* None:    停用此診斷
 
-End with `!` means override the group setting `diagnostics.groupFileStatus`.
+以 `!` 結尾的設定優先順序高於組設定 `diagnostics.groupFileStatus`。
 ]]
-config.diagnostics.groupSeverity  = -- TODO: need translate!
+config.diagnostics.groupSeverity  =
 [[
-Modify the diagnostic severity in a group.
-`Fallback` means that diagnostics in this group are controlled by `diagnostics.severity` separately.
-Other settings will override individual settings without end of `!`.
+批量修改一個組中的診斷等級。
+設定為 `Fallback` 意味著組中的診斷由 `diagnostics.severity` 單獨設定。
+其他設定將覆蓋單獨設定，但是不會覆蓋以 `!` 結尾的設定。
 ]]
-config.diagnostics.groupFileStatus = -- TODO: need translate!
+config.diagnostics.groupFileStatus =
 [[
-Modify the diagnostic needed file status in a group.
+批量修改一個組中的檔案狀態。
 
-* Opened:  only diagnose opened files
-* Any:     diagnose all files
-* None:    disable this diagnostic
+* Opened:  只診斷打開的檔案
+* Any:     診斷所有檔案
+* None:    停用此診斷
 
-`Fallback` means that diagnostics in this group are controlled by `diagnostics.neededFileStatus` separately.
-Other settings will override individual settings without end of `!`.
+設定為 `Fallback` 意味著組中的診斷由 `diagnostics.neededFileStatus` 單獨設定。
+其他設定將覆蓋單獨設定，但是不會覆蓋以 `!` 結尾的設定。
 ]]
 config.diagnostics.workspaceDelay =
-"進行工作區診斷的延遲（毫秒）。當你啟動工作區，或編輯了任意檔案後，將會在背景對整個工作區進行重新診斷。設定為負數可以停用工作區診斷。"
+"進行工作區診斷的延遲（毫秒）。當你啟動工作區，或編輯了任何檔案後，將會在背景對整個工作區進行重新診斷。設定為負數可以停用工作區診斷。"
 config.diagnostics.workspaceRate  =
-"工作區診斷的執行速率（百分比）。降低該值會減少CPU佔用，但是也會降低工作區診斷的速度。你目前正在編輯的檔案的診斷總是全速完成，不受該選項影響。"
+"工作區診斷的執行速率（百分比）。降低該值會減少CPU使用率，但是也會降低工作區診斷的速度。你目前正在編輯的檔案的診斷總是全速完成，不受該選項影響。"
 config.diagnostics.libraryFiles   =
 "如何診斷透過 `Lua.workspace.library` 載入的檔案。"
 config.diagnostics.libraryFiles.Enable   =
@@ -123,7 +122,7 @@ config.workspace.checkThirdParty  =
 config.workspace.userThirdParty          =
 '在這裡添加私有的第三方庫適應檔案路徑，請參考內建的[組態檔案路徑](https://github.com/sumneko/lua-language-server/tree/master/meta/3rd)'
 config.workspace.supportScheme           =
-'為以下 `scheme` 的lua檔案提供語言服務。'
+'為以下 `scheme` 的lua檔案提供語言伺服。'
 config.completion.enable                 =
 '啟用自動完成。'
 config.completion.callSnippet            =
@@ -175,7 +174,7 @@ config.semantic.enable                   =
 config.semantic.variable                 =
 "對變數/欄位/參數進行語義著色。"
 config.semantic.annotation               =
-"對型別註解進行語義著色。"
+"對類型註解進行語義著色。"
 config.semantic.keyword                  =
 "對關鍵字/字面常數/運算子進行語義著色。只有當你的編輯器無法進行語法著色時才需要啟用此功能。"
 config.signatureHelp.enable              =
@@ -189,14 +188,14 @@ config.hover.viewStringMax               =
 config.hover.viewNumber                  =
 "懸浮提示檢視數字內容（僅當字面常數不是十進制時）。"
 config.hover.fieldInfer                  =
-"懸浮提示檢視表時，會對表的每個欄位進行型別推測，當型別推測的用時累計達到該設定值（毫秒）時，將跳過後續欄位的型別推測。"
+"懸浮提示檢視表時，會對表的每個欄位進行類型推測，當類型推測的用時累計達到該設定值（毫秒）時，將跳過後續欄位的類型推測。"
 config.hover.previewFields               =
 "懸浮提示檢視表時，限制表內欄位的最大預覽數量。"
 config.hover.enumsLimit                  =
-"當值對應多個型別時，限制型別的顯示數量。"
-config.hover.expandAlias                 = -- TODO: need translate!
+"當值對應多個類型時，限制類型的顯示數量。"
+config.hover.expandAlias                 =
 [[
-Whether to expand the alias. For example, expands `---@alias myType boolean|number` appears as `boolean|number`, otherwise it appears as `myType'.
+是否展開別名。例如 `---@alias myType boolean|number` 展開後顯示為 `boolean|number`，否則顯示為 `myType'。
 ]]
 config.develop.enable                    =
 '開發者模式。請勿開啟，會影響效能。'
@@ -207,7 +206,7 @@ config.develop.debuggerWait              =
 config.intelliSense.searchDepth          =
 '設定智慧感知的搜尋深度。增大該值可以增加準確度，但會降低效能。不同的工作區對該設定的容忍度差異較大，請自己調整為合適的值。'
 config.intelliSense.fastGlobal           =
-'在對全域變數進行補全，及檢視 `_G` 的懸浮提示時進行最佳化。這會略微降低型別推測的準確度，但是對於大量使用全域變數的專案會有大幅的效能提升。'
+'在對全域變數進行補全，及檢視 `_G` 的懸浮提示時進行最佳化。這會略微降低類型推測的準確度，但是對於大量使用全域變數的專案會有大幅的效能提升。'
 config.window.statusBar                  =
 '在狀態欄顯示延伸模組狀態。'
 config.window.progressBar                =
@@ -215,15 +214,15 @@ config.window.progressBar                =
 config.hint.enable                       =
 '啟用內嵌提示。'
 config.hint.paramType                    =
-'在函式的參數位置提示型別。'
+'在函式的參數位置提示類型。'
 config.hint.setType                      =
-'在賦值操作位置提示型別。'
+'在賦值操作位置提示類型。'
 config.hint.paramName                    =
 '在函式呼叫處提示參數名。'
 config.hint.paramName.All                =
-'所有型別的參數均進行提示。'
+'所有類型的參數均進行提示。'
 config.hint.paramName.Literal            =
-'只有字面常數型別的參數進行提示。'
+'只有字面常數類型的參數進行提示。'
 config.hint.paramName.Disable            =
 '停用參數提示。'
 config.hint.arrayIndex                   =
@@ -231,34 +230,34 @@ config.hint.arrayIndex                   =
 config.hint.arrayIndex.Enable            =
 '所有的表中都提示陣列索引。'
 config.hint.arrayIndex.Auto              =
-'只有表大於3項，或者表是混合型別時才進行提示。'
+'只有表大於3項，或者表是混合類型時才進行提示。'
 config.hint.arrayIndex.Disable           =
 '停用陣列索引提示。'
-config.hint.await                        = -- TODO: need translate!
-'If the called function is marked `---@async`, prompt `await` at the call.'
+config.hint.await                        =
+'如果呼叫的函數被標記為了 `---@async`，則在呼叫處提示 `await`。'
 config.format.enable                     =
 '啟用程式碼格式化程式。'
-config.format.defaultConfig              = -- TODO: need translate!
+config.format.defaultConfig              =
 [[
-The default format configuration. Has a lower priority than `.editorconfig` file in the workspace.
-Read [formatter docs](https://github.com/CppCXY/EmmyLuaCodeStyle/tree/master/docs) to learn usage.
+預設的格式化組態，優先順序低於工作區內的 `.editorconfig` 檔案。
+請查閱[格式化文件](https://github.com/CppCXY/EmmyLuaCodeStyle/tree/master/docs)了解用法。
 ]]
-config.spell.dict                        = -- TODO: need translate!
-'Custom words for spell checking.'
+config.spell.dict                        =
+'拼寫檢查的自訂單詞。'
 config.telemetry.enable                  =
 [[
-啟用遙測，透過網路發送你的編輯器資訊與錯誤日誌。在[此處](https://github.com/sumneko/lua-language-server/wiki/%E9%9A%B1%E7%A7%81%E8%81%B2%E6%98%8E)閲讀我們的隱私聲明。
+啟用遙測，透過網路發送你的編輯器資訊與錯誤日誌。在[此處](https://github.com/sumneko/lua-language-server/wiki/%E9%9A%B1%E7%A7%81%E8%81%B2%E6%98%8E)閱讀我們的隱私聲明。
 ]]
 config.misc.parameters                   =
-'VSCode中啟動語言服務時的[命令列參數](https://github.com/sumneko/lua-language-server/wiki/Command-line)。'
+'VSCode中啟動語言伺服時的[命令列參數](https://github.com/sumneko/lua-language-server/wiki/Command-line)。'
 config.IntelliSense.traceLocalSet        =
-'請查閲[文件](https://github.com/sumneko/lua-language-server/wiki/IntelliSense-optional-features)瞭解用法。'
+'請查閱[文件](https://github.com/sumneko/lua-language-server/wiki/IntelliSense-optional-features)瞭解用法。'
 config.IntelliSense.traceReturn          =
-'請查閲[文件](https://github.com/sumneko/lua-language-server/wiki/IntelliSense-optional-features)瞭解用法。'
+'請查閱[文件](https://github.com/sumneko/lua-language-server/wiki/IntelliSense-optional-features)瞭解用法。'
 config.IntelliSense.traceBeSetted        =
-'請查閲[文件](https://github.com/sumneko/lua-language-server/wiki/IntelliSense-optional-features)瞭解用法。'
+'請查閱[文件](https://github.com/sumneko/lua-language-server/wiki/IntelliSense-optional-features)瞭解用法。'
 config.IntelliSense.traceFieldInject     =
-'請查閲[文件](https://github.com/sumneko/lua-language-server/wiki/IntelliSense-optional-features)瞭解用法。'
+'請查閱[文件](https://github.com/sumneko/lua-language-server/wiki/IntelliSense-optional-features)瞭解用法。'
 config.diagnostics['unused-local']          =
 '未使用的區域變數'
 config.diagnostics['unused-function']       =
@@ -266,7 +265,7 @@ config.diagnostics['unused-function']       =
 config.diagnostics['undefined-global']      =
 '未定義的全域變數'
 config.diagnostics['global-in-nil-env']     =
-'不能使用全域變數（ `_ENV` 被設定為了 `nil`）'
+'不能使用全域變數（ `_ENV` 被設定為 `nil`）'
 config.diagnostics['unused-label']          =
 '未使用的標籤'
 config.diagnostics['unused-vararg']         =
@@ -282,7 +281,7 @@ config.diagnostics['newfield-call']         =
 config.diagnostics['redundant-parameter']   =
 '函式呼叫時，傳入了多餘的引數'
 config.diagnostics['ambiguity-1']           =
-'優先級歧義，如： `num or 0 + 1` ，推測使用者的實際期望為 `(num or 0) + 1`'
+'優先順序歧義，如： `num or 0 + 1` ，推測使用者的實際期望為 `(num or 0) + 1`'
 config.diagnostics['lowercase-global']      =
 '首字母小寫的全域變數定義'
 config.diagnostics['undefined-env-child']   =


### PR DESCRIPTION
1. 翻譯 `zh_tw/script.lua` 內 `DIAG_CAST_LOCAL_TYPE`, `DIAG_CAST_FIELD_TYPE`, `DIAG_ASSIGN_TYPE_MISMATCH`, `DIAG_PARAM_TYPE_MISMATCH`, `DIAG_UNKNOWN_CAST_VARIABLE`, `DIAG_CAST_TYPE_MISMATCH`, `ACTION_ADD_DICT`, `COMMAND_ADD_DICT`, `LUADOC_DESC_CLASS`, `LUADOC_DESC_TYPE`, `LUADOC_DESC_ALIAS`, `LUADOC_DESC_PARAM`, `LUADOC_DESC_RETURN` `LUADOC_DESC_FIELD`, `LUADOC_DESC_GENERIC`, `LUADOC_DESC_VARARG`, `LUADOC_DESC_OVERLOAD`, `LUADOC_DESC_DEPRECATED`, `LUADOC_DESC_META`, `LUADOC_DESC_VERSION`, `LUADOC_DESC_SEE`, `LUADOC_DESC_DIAGNOSTIC`, `LUADOC_DESC_MODULE`, `LUADOC_DESC_ASYNC`, `LUADOC_DESC_NODISCARD`, `LUADOC_DESC_CAST`。
2. 翻譯 `zh_tw/settings.lua` 內 `config.runtime.meta`, `config.diagnostics.severity`, `config.diagnostics.neededFileStatus`, `config.diagnostics.groupSeverity`, `config.diagnostics.groupFileStatus`, `config.hover.expandAlias`, `config.hint.await`, `config.format.defaultConfig`, `config.spell.dict`。
3. `zh_tw/meta.lua` 內 `tonumber` 轉換失敗時的回傳值修正為 `fail` ，與 `en-us/meta.lua` 的描述一致。
4. `zh_tw/meta.lua` 內 `tostring` 有關$string.format的資訊放到最後一行。
5. `zh_tw/meta.lua` 內 `os.clock` 的描述改為 '回傳程式使用的 CPU 時間的近似值，單位為秒。'，我個人認為這樣更為通順。
6. `zh_tw/setting.lua` 內 `config.diagnostics.workspaceRate` 的描述改為 "...百分比）。降低該值會減少CPU使用率，但是也..."，也是為了通順。
7. 「閲」改成「閱」。 根據教育部《國語辭典簡編本》，「閱」是正字，而「閲」是異體字。
8. "process" 從「程序」改成「處理程序」，因為Windows工作管理員(Task Manager)是這樣翻譯的。
9. "data type" 從「型別」改成「類型」，因為Visual Studio C/C++是這樣翻譯的。
10. "metatable" 從「元表」改成「中繼資料表」，因 "metadata" 在微軟文件(Microsoft Docs)、Adobe官網和Canva說明中心內均被譯為「中繼資料」，取其 "meta" 為「中繼」之意。
11. "hook" 從「鉤子」改成「攔截」，因微軟文件將 "hook function" 譯為「攔截函式」。
12. "language server" 從 「語言服務」改成「語言伺服」，因為 "server" 一詞在繁體中文本來就是「伺服器」。
13. `script.lua` 內 `LUADOC_DESC_FIELD` 拼錯 "Declare" (拼成"Decalare")，已修正所有語言的檔案。
14. `script.lua` 內 `LUADOC_DESC_MODULE` 拼錯 "require" (拼成"reqire")，已修正所有語言的檔案。
15. 其他瑣碎的更改。