### PR TITLE
Array contents support

### DIFF
--- a/script/core/completion/completion.lua
+++ b/script/core/completion/completion.lua
@@ -1518,8 +1518,6 @@ local function tryArray(state, position, results)
     if source.type ~= 'table' and (not source.parent or source.parent.type ~= 'table') then
         return
     end
-    local mark = {}
-    local fields = {}
     local tbl = source
     if source.type ~= 'table' then
         tbl = source.parent

--- a/script/core/completion/completion.lua
+++ b/script/core/completion/completion.lua
@@ -56,6 +56,7 @@ local function trim(str)
 end
 
 local function findNearestSource(state, position)
+    ---@type parser.object
     local source
     guide.eachSourceContain(state.ast, position, function (src)
         source = src
@@ -1132,24 +1133,34 @@ local function cleanEnums(enums, source)
     return enums
 end
 
-local function checkTypingEnum(state, position, defs, str, results)
+---@return boolean
+local function insertEnum(state, src, enums, isInArray)
+    if src.type == 'doc.type.string'
+    or src.type == 'doc.type.integer'
+    or src.type == 'doc.type.boolean' then
+        ---@cast src parser.object
+        enums[#enums+1] = {
+            label       = vm.viewObject(src, state.uri),
+            description = src.comment,
+            kind        = define.CompletionItemKind.EnumMember,
+        }
+    elseif src.type == 'doc.type.code' then
+        enums[#enums+1] = {
+            label       = src[1],
+            description = src.comment,
+            kind        = define.CompletionItemKind.EnumMember,
+        }
+    elseif isInArray and src.type == 'doc.type.array' then
+        for i, d in ipairs(vm.getDefs(src.node)) do
+            insertEnum(state, d, enums, isInArray)
+        end
+    end
+end
+
+local function checkTypingEnum(state, position, defs, str, results, isInArray)
     local enums = {}
     for _, def in ipairs(defs) do
-        if def.type == 'doc.type.string'
-        or def.type == 'doc.type.integer'
-        or def.type == 'doc.type.boolean' then
-            enums[#enums+1] = {
-                label       = vm.viewObject(def, state.uri),
-                description = def.comment and def.comment.text,
-                kind        = define.CompletionItemKind.EnumMember,
-            }
-        elseif def.type == 'doc.type.code' then
-            enums[#enums+1] = {
-                label       = def[1],
-                description = def.comment and def.comment.text,
-                kind        = define.CompletionItemKind.EnumMember,
-            }
-        end
+        insertEnum(state, def, enums, isInArray)
     end
     cleanEnums(enums, str)
     for _, res in ipairs(enums) do
@@ -1157,7 +1168,7 @@ local function checkTypingEnum(state, position, defs, str, results)
     end
 end
 
-local function checkEqualEnumLeft(state, position, source, results)
+local function checkEqualEnumLeft(state, position, source, results, isInArray)
     if not source then
         return
     end
@@ -1167,7 +1178,7 @@ local function checkEqualEnumLeft(state, position, source, results)
         end
     end)
     local defs = vm.getDefs(source)
-    checkTypingEnum(state, position, defs, str, results)
+    checkTypingEnum(state, position, defs, str, results, isInArray)
 end
 
 local function checkEqualEnum(state, position, results)
@@ -1211,9 +1222,14 @@ local function checkEqualEnumInString(state, position, results)
         end
         checkEqualEnumLeft(state, position, parent[1], results)
     end
+    if (parent.type == 'tableexp') then
+        checkEqualEnumLeft(state, position, parent.parent.parent, results, true)
+        return
+    end
     if parent.type == 'local' then
         checkEqualEnumLeft(state, position, parent, results)
     end
+
     if parent.type == 'setlocal'
     or parent.type == 'setglobal'
     or parent.type == 'setfield'
@@ -1435,24 +1451,10 @@ local function tryCallArg(state, position, results)
     if not node then
         return
     end
+
     local enums = {}
     for src in node:eachObject() do
-        if src.type == 'doc.type.string'
-        or src.type == 'doc.type.integer'
-        or src.type == 'doc.type.boolean' then
-            ---@cast src parser.object
-            enums[#enums+1] = {
-                label       = vm.viewObject(src, state.uri),
-                description = src.comment,
-                kind        = define.CompletionItemKind.EnumMember,
-            }
-        elseif src.type == 'doc.type.code' then
-            enums[#enums+1] = {
-                label       = src[1],
-                description = src.comment,
-                kind        = define.CompletionItemKind.EnumMember,
-            }
-        end
+        insertEnum(state, src, enums, arg and arg.type == 'table')
         if src.type == 'doc.type.function' then
             ---@cast src parser.object
             local insertText = buildInsertDocFunction(src)
@@ -1496,6 +1498,7 @@ local function tryTable(state, position, results)
     if source.type ~= 'table' then
         tbl = source.parent
     end
+
     local defs = vm.getFields(tbl)
     for _, field in ipairs(defs) do
         local name = guide.getKeyName(field)
@@ -1505,6 +1508,24 @@ local function tryTable(state, position, results)
         end
     end
     checkTableLiteralField(state, position, tbl, fields, results)
+end
+
+local function tryArray(state, position, results)
+    local source = findNearestSource(state, position)
+    if not source then
+        return
+    end
+    if source.type ~= 'table' and (not source.parent or source.parent.type ~= 'table') then
+        return
+    end
+    local mark = {}
+    local fields = {}
+    local tbl = source
+    if source.type ~= 'table' then
+        tbl = source.parent
+    end
+    -- {  } inside when enum
+    checkEqualEnumLeft(state, position, tbl, results, true)
 end
 
 local function getComment(state, position)
@@ -2001,6 +2022,7 @@ local function tryCompletions(state, position, triggerCharacter, results)
     trySpecial(state, position, results)
     tryCallArg(state, position, results)
     tryTable(state, position, results)
+    tryArray(state, position, results)
     tryWord(state, position, triggerCharacter, results)
     tryIndex(state, position, results)
     trySymbol(state, position, results)

--- a/script/core/completion/completion.lua
+++ b/script/core/completion/completion.lua
@@ -1524,6 +1524,9 @@ local function tryArray(state, position, results)
     if source.type ~= 'table' then
         tbl = source.parent
     end
+    if source.parent.type == 'callargs' and source.parent.parent.type == 'call' then
+        return
+    end
     -- {  } inside when enum
     checkEqualEnumLeft(state, position, tbl, results, true)
 end

--- a/script/parser/guide.lua
+++ b/script/parser/guide.lua
@@ -889,6 +889,7 @@ local isSetMap = {
     ['doc.alias.name']    = true,
     ['doc.field.name']    = true,
     ['doc.type.field']    = true,
+    ['doc.type.array']    = true,
 }
 function m.isSet(source)
     local tp = source.type

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -1285,7 +1285,7 @@ local compilerSwitch = util.switch()
                     if not guide.isBasicType(pn.name) then
                         vm.setNode(source, pn)
                     end
-                elseif pn.type == 'doc.type.table' then
+                elseif pn.type == 'doc.type.table' or pn.type == 'doc.type.array' then
                     vm.setNode(source, pn)
                 end
             end

--- a/script/vm/compiler.lua
+++ b/script/vm/compiler.lua
@@ -1494,14 +1494,10 @@ local compilerSwitch = util.switch()
         if (source.parent.type == 'table') then
             local node = vm.compileNode(source.parent)
             for n in node:eachObject() do
-                if  (n.type == 'global'
-                and n.cate == 'type') then
-                    vm.setNode(source, vm.compileNode(n))
-                elseif n.type == 'doc.type.array' then
+                if n.type == 'doc.type.array' then
                     vm.setNode(source, vm.compileNode(n.node))
                 end
             end
-            return
         end
         vm.setNode(source, vm.compileNode(source.value))
     end)

--- a/test/completion/common.lua
+++ b/test/completion/common.lua
@@ -1640,6 +1640,264 @@ f('<??>')
 }
 
 TEST [[
+---@alias Option string | "AAA" | "BBB" | "CCC"
+---@param x Option[]
+function f(x)
+end
+
+f({<??>})
+]]
+{
+    {
+        label = '"AAA"',
+        kind = define.CompletionItemKind.EnumMember,
+        textEdit = EXISTS
+    },
+    {
+        label = '"BBB"',
+        kind = define.CompletionItemKind.EnumMember,
+        textEdit = EXISTS
+    },
+    {
+        label = '"CCC"',
+        kind = define.CompletionItemKind.EnumMember,
+        textEdit = EXISTS
+    }
+}
+
+TEST [[
+---@alias Option string | "AAA" | "BBB" | "CCC"
+---@param x Option[]
+function f(x)
+end
+
+f({"<??>"})
+]]
+{
+    {
+        label = '"AAA"',
+        kind = define.CompletionItemKind.EnumMember,
+        textEdit = EXISTS
+    },
+    {
+        label = '"BBB"',
+        kind = define.CompletionItemKind.EnumMember,
+        textEdit = EXISTS
+    },
+    {
+        label = '"CCC"',
+        kind = define.CompletionItemKind.EnumMember,
+        textEdit = EXISTS
+    }
+}
+
+TEST [[
+---@alias Option string | "AAA" | "BBB" | "CCC"
+---@param x Option[]
+function f(x)
+end
+
+f(<??>)
+]]
+    (nil)
+
+TEST [[
+---@alias Option "AAA" | "BBB" | "CCC"
+
+---@type Option[]
+local l = {<??>}
+]]
+{
+    {
+        label = '"AAA"',
+        kind = define.CompletionItemKind.EnumMember,
+    },
+    {
+        label = '"BBB"',
+        kind = define.CompletionItemKind.EnumMember,
+    },
+    {
+        label = '"CCC"',
+        kind = define.CompletionItemKind.EnumMember,
+    }
+}
+
+TEST [[
+---@alias Option "AAA" | "BBB" | "CCC"
+
+---@type Option[]
+local l = {"<??>"}
+]]
+{
+    {
+        label = '"AAA"',
+        kind = define.CompletionItemKind.EnumMember,
+        textEdit = EXISTS
+    },
+    {
+        label = '"BBB"',
+        kind = define.CompletionItemKind.EnumMember,
+        textEdit = EXISTS
+    },
+    {
+        label = '"CCC"',
+        kind = define.CompletionItemKind.EnumMember,
+        textEdit = EXISTS
+    }
+}
+
+TEST [[
+---@alias Option "AAA" | "BBB" | "CCC"
+
+---@type Option[]
+local l = <??>
+]]
+    (nil)
+
+TEST [[
+---@class OptionObj
+---@field a boolean
+---@field b boolean
+
+---@type OptionObj[]
+local l = { {<??>} }
+]]
+{
+    {
+        label = 'a',
+        kind = define.CompletionItemKind.Property,
+    },
+    {
+        label = 'b',
+        kind = define.CompletionItemKind.Property,
+    }
+}
+
+TEST [[
+---@class OptionObj
+---@field a boolean
+---@field b boolean
+
+---@type OptionObj[]
+local l = { <??> }
+]]
+    (nil)
+
+TEST [[
+---@class OptionObj
+---@field a boolean
+---@field b boolean
+
+---@type OptionObj[]
+local l = <??>
+]]
+    (nil)
+
+TEST [[
+---@class OptionObj
+---@field a boolean
+---@field b boolean
+---@field children OptionObj[]
+
+---@type OptionObj[]
+local l = { 
+    { 
+        a = true,
+        children = { {<??>} }
+    }
+}
+]]
+{
+    {
+        label = 'a',
+        kind = define.CompletionItemKind.Property,
+    },
+    {
+        label = 'b',
+        kind = define.CompletionItemKind.Property,
+    },
+    {
+        label = 'children',
+        kind = define.CompletionItemKind.Property,
+    }
+}
+
+TEST [[
+---@class OptionObj
+---@field a boolean
+---@field b boolean
+---@field children OptionObj[]
+
+---@type OptionObj[]
+local l = { 
+    { 
+        children = {<??>}
+    }
+}
+]]
+(nil)
+
+TEST [[
+---@class OptionObj
+---@field a boolean
+---@field b boolean
+---@field children OptionObj[]
+
+---@type OptionObj[]
+local l = { 
+    { 
+        children = <??>
+    }
+}
+]]
+(nil)
+
+TEST [[
+---@class OptionObj
+---@field a boolean
+---@field b boolean
+---@param x OptionObj[]
+function f(x)
+end
+
+f({ {<??>} })
+]]
+{
+    {
+        label = 'a',
+        kind = define.CompletionItemKind.Property,
+    },
+    {
+        label = 'b',
+        kind = define.CompletionItemKind.Property,
+    }
+}
+
+TEST [[
+---@class OptionObj
+---@field a boolean
+---@field b boolean
+---@param x OptionObj[]
+function f(x)
+end
+
+f({<??>})
+]]
+    (nil)
+
+TEST [[
+---@class OptionObj
+---@field a boolean
+---@field b boolean
+---@param x OptionObj[]
+function f(x)
+end
+
+f(<??>)
+]]
+    (nil)
+
+TEST [[
 ---this is
 ---a multi line
 ---comment


### PR DESCRIPTION
Add support for auto complete in cases where using an array. A simple example is like these, more in unit tests
```lua
---@alias Option "AAA" | "BBB" | "CCC"

---@type Option[]
local l = {"<??>"}

---@class OptionObj
---@field a boolean
---@field b boolean

---@type OptionObj[]
local l = { {<??>} }
```

these 2 examples will autocomplete with either the expected enum for the first case, or the expected object fields in the second.

Also, I might have screwed up the merge for sub modules, but I think I did it right?