### PR TITLE
Fix `dofile` returns multiple values `---@return any ...`

### DIFF
--- a/meta/template/basic.lua
+++ b/meta/template/basic.lua
@@ -41,7 +41,7 @@ function collectgarbage(opt, arg) end
 
 ---#DES 'dofile'
 ---@param filename? string
----@return any
+---@return any ...
 function dofile(filename) end
 
 ---#DES 'error'


### PR DESCRIPTION
This is a `dofile` fix that returns multiple any values https://github.com/sumneko/lua-language-server/issues/1207

> ---Opens the named file and executes its content as a Lua chunk. 
Returns all values returned by the chunk.
