### PR TITLE
add custom operator support for number and integer

### DIFF
--- a/script/vm/operator.lua
+++ b/script/vm/operator.lua
@@ -98,6 +98,12 @@ function vm.runOperator(op, exp, value)
         if c.type == 'string'
         or c.type == 'doc.type.string' then
             c = vm.declareGlobal('type', 'string')
+        elseif c.type == 'number'
+        or c.type == 'doc.type.number' then
+            c = vm.declareGlobal('type', 'number')
+        elseif c.type == 'integer'
+        or c.type == 'doc.type.integer' then
+            c = vm.declareGlobal('type', 'integer')
         end
         if c.type == 'global' and c.cate == 'type' then
             ---@cast c vm.global


### PR DESCRIPTION
This PR adds support for extending the number / integer operators.

For example if you have a Vector3 class that could be multiplied with now this will work
```lua
---@class integer
---@operator mul(Vector3): Vector3
```

```lua
---@class number
---@operator mul(Vector3): Vector3
```


```lua
local shouldShowupAsAVector3 = 1.0 * Vector3.New(1,2,3);
```
