### PR TITLE
Meta: make osdate accept strings

### DIFF
--- a/meta/template/os.lua
+++ b/meta/template/os.lua
@@ -11,21 +11,21 @@ function os.clock() end
 
 ---@class osdate
 ---#DES 'osdate.year'
----@field year  integer
+---@field year  integer|string
 ---#DES 'osdate.month'
----@field month integer
+---@field month integer|string
 ---#DES 'osdate.day'
----@field day   integer
+---@field day   integer|string
 ---#DES 'osdate.hour'
----@field hour  integer
+---@field hour  integer|string
 ---#DES 'osdate.min'
----@field min   integer
+---@field min   integer|string
 ---#DES 'osdate.sec'
----@field sec   integer
+---@field sec   integer|string
 ---#DES 'osdate.wday'
----@field wday  integer
+---@field wday  integer|string
 ---#DES 'osdate.yday'
----@field yday  integer
+---@field yday  integer|string
 ---#DES 'osdate.isdst'
 ---@field isdst boolean
 


### PR DESCRIPTION
The `os.time` function accepts strings as input:

![image](https://user-images.githubusercontent.com/6566889/178788401-6eff0df7-6006-4417-acaa-940196f3ac3e.png)

With this small change, it works as expected:

![image](https://user-images.githubusercontent.com/6566889/178788799-9f6b1df1-2d63-463a-b629-44e9d80b7456.png)
