### PR TITLE
make integer a alias to number type.

### DIFF
--- a/meta/template/builtin.lua
+++ b/meta/template/builtin.lua
@@ -7,7 +7,7 @@
 ---@class true: boolean
 ---@class false: boolean
 ---@class number
----@class integer: number
+---@alias integer number
 ---@class thread
 ---@class table<K, V>: { [K]: V }
 ---@class string: stringlib


### PR DESCRIPTION
integer类型的参数, 接收number型的传入值时,会有类型不匹配的警告. 
在integer没有区别于number的其他特殊定义时, 将integer直接别名化, 可以避免代码中 number 与 integer 的 param-type-mismatch.