### PR TITLE
add color support

### DIFF
--- a/script/core/color.lua
+++ b/script/core/color.lua
@@ -1,0 +1,77 @@
+local files = require "files"
+local guide = require "parser.guide"
+
+local colorPattern = string.rep('%x', 8)
+---@param source parser.object
+---@return boolean
+local function isColor(source)
+    ---@type string
+    local text = source[1]
+    if text:len() ~= 8 then
+        return false
+    end
+    return text:match(colorPattern)
+end
+
+
+---@param colorText string
+---@return Color
+local function textToColor(colorText)
+    return {
+        alpha = tonumber(colorText:sub(1, 2), 16) / 255,
+        red = tonumber(colorText:sub(3, 4), 16) / 255,
+        green = tonumber(colorText:sub(5, 6), 16) / 255,
+        blue = tonumber(colorText:sub(7, 8), 16) / 255,
+    }
+end
+
+
+---@param color Color
+---@return string
+local function colorToText(color)
+    return (''
+        .. string.format('%02x', math.tointeger(color.alpha * 255))
+        .. string.format('%02x', math.tointeger(color.red * 255))
+        .. string.format('%02x', math.tointeger(color.green * 255))
+        .. string.format('%02x', math.tointeger(color.blue * 255))):upper()
+end
+
+---@class Color
+---@field red number
+---@field green number
+---@field blue number
+---@field alpha number
+
+---@class ColorValue
+---@field color Color
+---@field start integer
+---@field finish integer
+
+---@async
+function colors(uri)
+    local state = files.getState(uri)
+    local text  = files.getText(uri)
+    if not state or not text then
+        return nil
+    end
+    ---@type ColorValue[]
+    local colors = {}
+
+    guide.eachSource(state.ast, function (source) ---@async
+        if source.type == 'string' and isColor(source) then
+            ---@type string
+            local colorText = source[1]
+            
+            colors[#colors+1] = {
+                start = source.start + 1,
+                finish = source.finish - 1,
+                color = textToColor(colorText)
+            }
+        end
+    end)
+    return colors
+end
+return {
+    colors = colors,
+    colorToText = colorToText
+}

--- a/script/provider/provider.lua
+++ b/script/provider/provider.lua
@@ -1021,6 +1021,40 @@ m.register 'textDocument/foldingRange' {
     end
 }
 
+m.register 'textDocument/documentColor' {
+    capability = {
+        colorProvider = true
+    },
+    ---@async
+    function (params)
+        local color = require 'core.color'
+        local uri     = files.getRealUri(params.textDocument.uri)
+        workspace.awaitReady(uri)
+        if not files.exists(uri) then
+            return nil
+        end
+        local colors = color.colors(uri)
+        if not colors then
+            return nil
+        end
+        local results = {}
+        for _, colorValue in ipairs(colors) do
+            results[#results+1] = {
+                range = converter.packRange(uri, colorValue.start, colorValue.finish),
+                color = colorValue.color
+            }
+        end
+        return results
+    end
+}
+
+m.register 'textDocument/colorPresentation' {
+    function (params)
+        local color = (require 'core.color').colorToText(params.color)
+        return {{label = color}}
+    end
+}
+
 m.register 'window/workDoneProgress/cancel' {
     function (params)
         log.debug('close proto(cancel):', params.token)


### PR DESCRIPTION
Not sure this will really be useful the way it's written right now but it works for my fork and I thought I'd contribute it back upstream in-case this could be used in conjunction with some kind of Color type. 

With some configuration settings it could probably be made useful to others. The hard part is mapping a color to text and back again kinda has to be custom, but we could make some templates that could cover most cases, maybe even as a plugin someone could provide the converting and testing code?

Basically it enables color decorators when it finds a string with 8 hex chars in it's current configuration.
![image](https://code.visualstudio.com/assets/api/language-extensions/language-support/color-decorators.png)
