### PR TITLE
Update love.graphics API

### DIFF
--- a/meta/3rd/love2d/library/love.graphics.lua
+++ b/meta/3rd/love2d/library/love.graphics.lua
@@ -86,7 +86,7 @@ function love.graphics.discard(discardcolor, discardstencil) end
 ---
 ---Objects are drawn relative to their local coordinate system. The origin is by default located at the top left corner of Image and Canvas. All scaling, shearing, and rotation arguments transform the object relative to that point. Also, the position of the origin can be specified on the screen coordinate system.
 ---
----It's possible to rotate an object about its center by offsetting the origin to the center. Angles must be given in radians for rotation. One can also use a negative scaling factor to flip about its centerline. 
+---It's possible to rotate an object about its center by offsetting the origin to the center. Angles must be given in radians for rotation. One can also use a negative scaling factor to flip about its centerline.
 ---
 ---Note that the offsets are applied before rotation, scaling, or shearing; scaling and shearing are applied before rotation.
 ---
@@ -350,7 +350,7 @@ function love.graphics.getPointSize() end
 ---
 ---@return string name # The name of the renderer, e.g. 'OpenGL' or 'OpenGL ES'.
 ---@return string version # The version of the renderer with some extra driver-dependent version info, e.g. '2.1 INTEL-8.10.44'.
----@return string vendor # The name of the graphics card vendor, e.g. 'Intel Inc'. 
+---@return string vendor # The name of the graphics card vendor, e.g. 'Intel Inc'.
 ---@return string device # The name of the graphics card, e.g. 'Intel HD Graphics 3000 OpenGL Engine'.
 function love.graphics.getRendererInfo() end
 
@@ -376,7 +376,7 @@ function love.graphics.getShader() end
 function love.graphics.getStackDepth() end
 
 ---
----Gets performance-related rendering statistics. 
+---Gets performance-related rendering statistics.
 ---
 ---@overload fun(stats: table):table
 ---@return {drawcalls: number, canvasswitches: number, texturememory: number, images: number, canvases: number, fonts: number, shaderswitches: number, drawcallsbatched: number} stats # A table with the following fields:
@@ -841,7 +841,7 @@ function love.graphics.scale(sx, sy) end
 ---Sets the background color.
 ---
 ---@overload fun()
----@overload fun()
+---@overload fun(rgba: table)
 ---@param red number # The red component (0-1).
 ---@param green number # The green component (0-1).
 ---@param blue number # The blue component (0-1).
@@ -970,7 +970,7 @@ function love.graphics.setPointSize(size) end
 ---
 ---Sets or disables scissor.
 ---
----The scissor limits the drawing area to a specified rectangle. This affects all graphics calls, including love.graphics.clear. 
+---The scissor limits the drawing area to a specified rectangle. This affects all graphics calls, including love.graphics.clear.
 ---
 ---The dimensions of the scissor is unaffected by graphical transformations (translate, scale, ...).
 ---
@@ -1038,7 +1038,7 @@ function love.graphics.transformPoint(globalX, globalY) end
 ---
 ---Translates the coordinate system in two dimensions.
 ---
----When this function is called with two numbers, dx, and dy, all the following drawing operations take effect as if their x and y coordinates were x+dx and y+dy. 
+---When this function is called with two numbers, dx, and dy, all the following drawing operations take effect as if their x and y coordinates were x+dx and y+dy.
 ---
 ---Scale and translate are not commutative operations, therefore, calling them in different orders will change the outcome.
 ---
@@ -1702,10 +1702,10 @@ function ParticleSystem:setBufferSize(size) end
 ---@param g2 number # Second color, green component (0-1).
 ---@param b2 number # Second color, blue component (0-1).
 ---@param a2 number # Second color, alpha component (0-1).
----@param r8 number # Eighth color, red component (0-1).
----@param g8 number # Eighth color, green component (0-1).
----@param b8 number # Eighth color, blue component (0-1).
----@param a8 number # Eighth color, alpha component (0-1).
+---@param r8? number # Eighth color, red component (0-1).
+---@param g8? number # Eighth color, green component (0-1).
+---@param b8? number # Eighth color, blue component (0-1).
+---@param a8? number # Eighth color, alpha component (0-1).
 function ParticleSystem:setColors(r1, g1, b1, a1, r2, g2, b2, a2, r8, g8, b8, a8) end
 
 ---
@@ -1824,7 +1824,7 @@ function ParticleSystem:setSizeVariation(variation) end
 ---
 ---@param size1 number # The first size.
 ---@param size2 number # The second size.
----@param size8 number # The eighth size.
+---@param size8? number # The eighth size.
 function ParticleSystem:setSizes(size1, size2, size8) end
 
 ---
@@ -2918,7 +2918,7 @@ function Video:tell() end
 ---
 ---@alias love.SpriteBatchUsage
 ---
----The object's data will change occasionally during its lifetime. 
+---The object's data will change occasionally during its lifetime.
 ---
 ---| "dynamic"
 ---


### PR DESCRIPTION
I got a few annoying (and wrong) new warnings that I decided to fix locally then created a PR to fix it for everybody,
- setBackgroundColor was missing the option to pass a table (like setColor)
- particle's setColor and setSizes was putting optional parameters as required
- my formatter removed a few trailing whitespaces btw