### PR TITLE
fix inappropriate definition of `utf8.offset`

### DIFF
--- a/meta/template/utf8.lua
+++ b/meta/template/utf8.lua
@@ -70,7 +70,7 @@ function utf8.len(s, i, j, lax) end
 ---#DES 'utf8.offset'
 ---@param s string
 ---@param n integer
----@param i integer
+---@param i? integer
 ---@return integer p
 ---@nodiscard
 function utf8.offset(s, n, i) end


### PR DESCRIPTION
The third parameter `i` of `utf8.offset` should be optional according to Lua Reference Manual, where the definition of it is `utf8.offset (s, n [, i])`.
