### PR TITLE
type format 在键入换行时补全表项的逗号

### DIFF
--- a/script/config/template.lua
+++ b/script/config/template.lua
@@ -375,7 +375,8 @@ local template = {
     ['Lua.typeFormat.config']               = Type.Hash(Type.String, Type.String)
                                             >> {
                                                 format_line = "true",
-                                                auto_complete_end = "true"
+                                                auto_complete_end = "true",
+                                                auto_complete_table_sep = "true"
                                             },
     ['Lua.spell.dict']                      = Type.Array(Type.String),
     ['Lua.telemetry.enable']                = Type.Or(Type.Boolean >> false, Type.Nil) >> nil,


### PR DESCRIPTION
该功能是基于format_line，当表跨行表达时，在最后一个表项后键入 enter会自动填补逗号。
功能的灵感来自于webstorm在编辑json文件时的行为。
那么该项特性有这么几个问题。
1. 其实现依赖格式化本身的功能，不开format_line无法使用，是否应该独立实现
2. 该特性会不会造成困扰
3. 该特性是否应该默认开启？
