### PR TITLE
Replace old variable return syntax

### DIFF
--- a/meta/3rd/OpenResty/library/ngx.lua
+++ b/meta/3rd/OpenResty/library/ngx.lua
@@ -4382,7 +4382,7 @@ function ngx.resp.get_headers(max_headers, raw) end
 ---@param ... ngx.thread.arg
 ---@return boolean ok
 ---@return ngx.thread.arg? result_or_error
----@return ...
+---@return any ...
 function ngx.run_worker_thread(threadpool, module_name, func_name, arg1, arg2, ...)
 end
 

--- a/meta/3rd/skynet/library/skynet.lua
+++ b/meta/3rd/skynet/library/skynet.lua
@@ -159,7 +159,7 @@ end
 ---* 将 C 指针 或字符串转换成 Lua 数据
 ---@param msg lightuserdata | string
 ---@param sz? number
----@return ...
+---@return any ...
 function skynet.unpack(msg, sz)
 end
 

--- a/meta/template/basic.lua
+++ b/meta/template/basic.lua
@@ -9,7 +9,7 @@ arg = {}
 ---@param v? T
 ---@param message? any
 ---@return T
----@return ...
+---@return any ...
 function assert(v, message, ...) end
 
 ---@alias gcoptions
@@ -163,7 +163,7 @@ function pairs(t) end
 ---@param arg1? any
 ---@return boolean success
 ---@return any result
----@return ...
+---@return any ...
 function pcall(f, arg1, ...) end
 
 ---#DES 'print'
@@ -269,7 +269,7 @@ function warn(message, ...) end
 ---@param err   function
 ---@return boolean success
 ---@return any result
----@return ...
+---@return any ...
 function xpcall(f, err) end
 ---#else
 ---#DES 'xpcall>5.2'
@@ -278,7 +278,7 @@ function xpcall(f, err) end
 ---@param arg1? any
 ---@return boolean success
 ---@return any result
----@return ...
+---@return any ...
 function xpcall(f, msgh, arg1, ...) end
 ---#end
 

--- a/meta/template/coroutine.lua
+++ b/meta/template/coroutine.lua
@@ -34,8 +34,7 @@ function coroutine.close(co) end
 ---@param co    thread
 ---@param val1? any
 ---@return boolean success
----@return any result
----@return ...
+---@return any ...
 function coroutine.resume(co, val1, ...) end
 
 ---#DES 'coroutine.running'
@@ -62,7 +61,7 @@ function coroutine.wrap(f) end
 
 ---#DES 'coroutine.yield'
 ---@async
----@return ...
+---@return any ...
 function coroutine.yield(...) end
 
 return coroutine

--- a/meta/template/io.lua
+++ b/meta/template/io.lua
@@ -72,7 +72,7 @@ function io.popen(prog, mode) end
 ---#DES 'io.read'
 ---@param ... readmode
 ---@return any
----@return ...
+---@return any ...
 ---@nodiscard
 function io.read(...) end
 
@@ -135,7 +135,7 @@ function file:lines(...) end
 ---#DES 'file:read'
 ---@param ... readmode
 ---@return any
----@return ...
+---@return any ...
 ---@nodiscard
 function file:read(...) end
 

--- a/meta/template/jit.lua
+++ b/meta/template/jit.lua
@@ -26,7 +26,7 @@ function jit.off(func, recursive) end
 function jit.flush(func, recursive) end
 
 ---@return boolean status
----@return ...
+---@return any ...
 ---@nodiscard
 function jit.status() end
 

--- a/meta/template/jit.lua
+++ b/meta/template/jit.lua
@@ -26,7 +26,7 @@ function jit.off(func, recursive) end
 function jit.flush(func, recursive) end
 
 ---@return boolean status
----@return any ...
+---@return string ...
 ---@nodiscard
 function jit.status() end
 

--- a/meta/template/string.lua
+++ b/meta/template/string.lua
@@ -8,8 +8,7 @@ string = {}
 ---@param s  string
 ---@param i? integer
 ---@param j? integer
----@return integer
----@return ...
+---@return integer ...
 ---@nodiscard
 function string.byte(s, i, j) end
 
@@ -17,7 +16,6 @@ function string.byte(s, i, j) end
 ---@param byte integer
 ---@param ... integer
 ---@return string
----@return ...
 ---@nodiscard
 function string.char(byte, ...) end
 
@@ -35,7 +33,7 @@ function string.dump(f, strip) end
 ---@param plain?  boolean
 ---@return integer start
 ---@return integer end
----@return ... captured
+---@return string|integer ... captured
 ---@nodiscard
 function string.find(s, pattern, init, plain) end
 
@@ -87,7 +85,7 @@ function string.lower(s) end
 ---@param s       string
 ---@param pattern string
 ---@param init?   integer
----@return ... captured
+---@return string|integer|nil ...
 ---@nodiscard
 function string.match(s, pattern, init) end
 
@@ -143,7 +141,7 @@ function string.sub(s, i, j) end
 ---@param fmt  string
 ---@param s    string
 ---@param pos? integer
----@return ...
+---@return any ...
 ---@return integer offset
 ---@nodiscard
 function string.unpack(fmt, s, pos) end

--- a/script/utility.lua
+++ b/script/utility.lua
@@ -730,7 +730,7 @@ function switchMT:has(name)
 end
 
 ---@param name string
----@return ...
+---@return any ...
 function switchMT:__call(name, ...)
     local callback = self.map[name] or self._default
     if not callback then


### PR DESCRIPTION
As discovered in #1539, some of the meta files still use the old `@return` syntax.

This PR serves to fix all the old syntaxes. I do not use any of the third party libraries included by default though so I need some help to figure out what the return types are for those.