### PR TITLE
Use strict pattern to trigger attaching the lfs library

### DIFF
--- a/meta/3rd/lfs/config.lua
+++ b/meta/3rd/lfs/config.lua
@@ -1,5 +1,5 @@
 name = 'luafilesystem'
-words = { 'lfs%.%w+' }
+words = { 'require[%s%(\"\']+lfs[%)\"\']' }
 configs = {
     {
         key    = 'Lua.diagnostics.globals',

--- a/meta/3rd/lfs/library/lfs.lua
+++ b/meta/3rd/lfs/library/lfs.lua
@@ -95,7 +95,6 @@ end
 ---@param symlink? boolean
 ---@return boolean, string
 function lfs.link(old, new, symlink)
-
 end
 
 --[[


### PR DESCRIPTION
Pattern 'lfs%.%w+' is too greedy.
A script using the 'lfs' always contains string "requre('lfs')",
so new pattern uses 'requre...'