### PR TITLE
fix: pathStrict should also look for strict path uris in workspace libraries

### DIFF
--- a/script/workspace/require-path.lua
+++ b/script/workspace/require-path.lua
@@ -179,21 +179,21 @@ function mt:findUrisByRequireName(suri, name)
                 searcherMap[fullUri] = searcher
             end
         end
-        if not strict then
-            local tail = '/' .. furi.encode(fspath):gsub('^file:[/]*', '')
-            for uri in files.eachFile(self.scp.uri) do
-                if  not searcherMap[uri]
-                and suri ~= uri
-                and util.stringEndWith(uri, tail) then
-                    results[#results+1] = uri
-                    local parentUri = files.getLibraryUri(self.scp.uri, uri) or self.scp.uri
-                    if parentUri == nil or parentUri == '' then
-                        parentUri = furi.encode ''
-                    end
-                    local relative  = uri:sub(#parentUri + 1):sub(1, - #tail)
-                    searcherMap[uri] = workspace.normalize(relative .. searcher)
-                end
-            end
+        local tail = '/' .. furi.encode(fspath):gsub('^file:[/]*', '')
+        for uri in files.eachFile(self.scp.uri) do
+          if  not searcherMap[uri]
+            and suri ~= uri
+            and util.stringEndWith(uri, tail) then
+              local parentUri = files.getLibraryUri(self.scp.uri, uri) or self.scp.uri
+              if parentUri == nil or parentUri == '' then
+                parentUri = furi.encode ''
+              end
+              local relative  = uri:sub(#parentUri + 1):sub(1, - #tail)
+              if not strict or relative == "/" then
+                results[#results+1] = uri
+              end
+              searcherMap[uri] = workspace.normalize(relative .. searcher)
+          end
         end
     end
 


### PR DESCRIPTION
When ebabling `pathStrict`, **lua-language-server** properly lists completion for require paths, but can't actually resolve the `require` if it's a strict path from a library.

This PR fixes that.

Any file where the **tail** mathes with a library file and where the relative path in the library is `/`, should be included when **pathStrict** is enabled.