### PR TITLE
Make second param of ffi.gc optional

### DIFF
--- a/meta/template/ffi.lua
+++ b/meta/template/ffi.lua
@@ -57,7 +57,7 @@ function ffi.cast(ct, init) end
 function ffi.metatype(ct, metatable) end
 
 ---@param cdata     ffi.cdata*
----@param finalizer function
+---@param finalizer? function
 ---@return ffi.cdata* cdata
 function ffi.gc(cdata, finalizer) end
 


### PR DESCRIPTION
According to the LuaJIT [ffi API reference](https://luajit.org/ext_ffi_api.html#ffi_gc) nil is a valid value for the finalizer.