### PR TITLE
Use tables of tables as enums

### DIFF
--- a/script/core/completion/completion.lua
+++ b/script/core/completion/completion.lua
@@ -1157,7 +1157,8 @@ local function insertDocEnum(state, pos, doc, enums)
                 goto CONTINUE
             end
             if field.value.type == 'integer'
-            or field.value.type == 'string' then
+            or field.value.type == 'string'
+            or field.value.type == 'table' then
                 if parentName then
                     enums[#enums+1] = {
                         label  = parentName .. '.' .. key,
@@ -1171,7 +1172,8 @@ local function insertDocEnum(state, pos, doc, enums)
                     }
                 end
                 valueEnums[#valueEnums+1] = {
-                    label  = util.viewLiteral(field.value[1]),
+                    label  = field.value.type == 'table' and 'table'
+                        or util.viewLiteral(field.value[1]),
                     kind   = define.CompletionItemKind.EnumMember,
                     id     = stack(function () ---@async
                         return {
@@ -1212,7 +1214,7 @@ local function insertEnum(state, pos, src, enums, isInArray)
             kind        = define.CompletionItemKind.EnumMember,
         }
     elseif isInArray and src.type == 'doc.type.array' then
-        for i, d in ipairs(vm.getDefs(src.node)) do
+        for _, d in ipairs(vm.getDefs(src.node)) do
             insertEnum(state, pos, d, enums, isInArray)
         end
     elseif src.type == 'global' and src.cate == 'type' then
@@ -1917,7 +1919,7 @@ local function tryluaDocByErr(state, position, err, docState, results)
         end
         local label = {}
         local insertText = {}
-        for i, arg in ipairs(func.args) do
+        for _, arg in ipairs(func.args) do
             if arg[1] and arg.type ~= 'self' then
                 label[#label+1] = arg[1]
                 if #label == 1 then
@@ -1933,7 +1935,7 @@ local function tryluaDocByErr(state, position, err, docState, results)
             insertTextFormat = 2,
             insertText       = table.concat(insertText, '\n'),
         }
-        for i, arg in ipairs(func.args) do
+        for _, arg in ipairs(func.args) do
             if arg[1] then
                 results[#results+1] = {
                     label  = arg[1],

--- a/script/vm/global.lua
+++ b/script/vm/global.lua
@@ -145,7 +145,7 @@ end
 
 ---@class parser.object
 ---@field _globalNode vm.global|false
----@field _enums?     (string|integer)[]
+---@field _enums?     (string|integer|table)[]
 
 ---@type table<string, vm.global>
 local allGlobals = {}
@@ -362,7 +362,8 @@ local compilerGlobalSwitch = util.switch()
                     goto CONTINUE
                 end
                 if field.value.type == 'integer'
-                or field.value.type == 'string' then
+                or field.value.type == 'string'
+                or field.value.type == 'table' then
                     source._enums[#source._enums+1] = field.value[1]
                 end
                 if field.value.type == 'binary'

--- a/script/vm/type.lua
+++ b/script/vm/type.lua
@@ -55,13 +55,6 @@ local function checkEnum(parentName, child, uri)
             if not set._enums then
                 return false
             end
-            if  child.type ~= 'string'
-            and child.type ~= 'doc.type.string'
-            and child.type ~= 'integer'
-            and child.type ~= 'number'
-            and child.type ~= 'doc.type.integer' then
-                return false
-            end
             return util.arrayHas(set._enums, child[1])
         end
     end
@@ -73,17 +66,10 @@ end
 ---@param child  vm.node.object
 ---@return boolean
 local function checkValue(parent, child)
-    if parent.type == 'doc.type.integer' then
-        if child.type == 'integer'
-        or child.type == 'doc.type.integer'
-        or child.type == 'number' then
-            return parent[1] == child[1]
-        end
-    elseif parent.type == 'doc.type.string' then
-        if child.type == 'string'
-        or child.type == 'doc.type.string' then
-            return parent[1] == child[1]
-        end
+    if parent.type == 'doc.type.integer'
+    or parent.type == 'doc.type.string'
+    or parent.type == 'doc.type.table' then
+        return parent[1] == child[1]
     end
 
     return true

--- a/test/completion/common.lua
+++ b/test/completion/common.lua
@@ -1800,8 +1800,8 @@ TEST [[
 ---@field children OptionObj[]
 
 ---@type OptionObj[]
-local l = { 
-    { 
+local l = {
+    {
         a = true,
         children = { {<??>} }
     }
@@ -1829,8 +1829,8 @@ TEST [[
 ---@field children OptionObj[]
 
 ---@type OptionObj[]
-local l = { 
-    { 
+local l = {
+    {
         children = {<??>}
     }
 }
@@ -1844,8 +1844,8 @@ TEST [[
 ---@field children OptionObj[]
 
 ---@type OptionObj[]
-local l = { 
-    { 
+local l = {
+    {
         children = <??>
     }
 }
@@ -3641,6 +3641,7 @@ TEST [[
 T = {
     x = 1,
     y = 'ss',
+    z = { 'uu' },
 }
 
 ---@param x A
@@ -3658,11 +3659,19 @@ f(<??>)
         kind     = define.CompletionItemKind.EnumMember,
     },
     {
+        label    = 'T.z',
+        kind     = define.CompletionItemKind.EnumMember,
+    },
+    {
         label    = '1',
         kind     = define.CompletionItemKind.EnumMember,
     },
     {
         label    = '"ss"',
+        kind     = define.CompletionItemKind.EnumMember,
+    },
+    {
+        label    = 'table',
         kind     = define.CompletionItemKind.EnumMember,
     },
 }
@@ -3672,6 +3681,7 @@ TEST [[
 local ppp = {
     x = 1,
     y = 'ss',
+    z = { 'uu' },
 }
 
 ---@param x A
@@ -3689,11 +3699,19 @@ f(<??>)
         kind     = define.CompletionItemKind.EnumMember,
     },
     {
+        label    = 'ppp.z',
+        kind     = define.CompletionItemKind.EnumMember,
+    },
+    {
         label    = '1',
         kind     = define.CompletionItemKind.EnumMember,
     },
     {
         label    = '"ss"',
+        kind     = define.CompletionItemKind.EnumMember,
+    },
+    {
+        label    = 'table',
         kind     = define.CompletionItemKind.EnumMember,
     },
 }
@@ -3703,6 +3721,7 @@ TEST [[
 ppp.fff = {
     x = 1,
     y = 'ss',
+    z = { 'uu' },
 }
 
 ---@param x A
@@ -3720,11 +3739,19 @@ f(<??>)
         kind     = define.CompletionItemKind.EnumMember,
     },
     {
+        label    = 'ppp.fff.z',
+        kind     = define.CompletionItemKind.EnumMember,
+    },
+    {
         label    = '1',
         kind     = define.CompletionItemKind.EnumMember,
     },
     {
         label    = '"ss"',
+        kind     = define.CompletionItemKind.EnumMember,
+    },
+    {
+        label    = 'table',
         kind     = define.CompletionItemKind.EnumMember,
     },
 }


### PR DESCRIPTION
**This PR is incomplete.** I have been writing it for a couple of days but I can't make it work, so I'd like some pointers on how to proceed with the implementation so that I can finish it and add it to the project. I thought that this was a nice contribution for the hacktoberfest, but it's proving more daunting than I first thought. Still, I want to finish it because it would be beneficial for many projects.

## Motivation for this PR

Right now, enums are defined as table of integer or string literals. Sometimes, more complex elements may want to be added to the enum table so that a field can be limited to complex values:

```lua
---@enum LogLevels
local log_levels = {
    trace = { hl = "Comment",    level = vim_log_levels.TRACE },
    debug = { hl = "Comment",    level = vim_log_levels.DEBUG },
    info  = { hl = "None",       level = vim_log_levels.INFO },
    warn  = { hl = "WarningMsg", level = vim_log_levels.WARN },
    error = { hl = "ErrorMsg",   level = vim_log_levels.ERROR },
    fatal = { hl = "ErrorMsg",   level = 5 },
}

---@class LogConfig
---@field level LogLevels #Any messages above this level will be logged.
local default_config = {
    level = log_levels.warn,
}
```

## What I've tried so far

I've first added tests to check that the PR is functional and they pass. Admittedly, they just define `table` as the description for the table field. It is *good enough* but it could be more descriptive. **The tests pass, but the completions are not functional.**

To make the tests pass, I've removed some type restrictions to accept all types in a couple of enum-related functions and extended it in others to also accept the `table` type. I'm still playing with these restrictions and seeing how they can be corrected.

I'm sure I'm missing a big piece of the puzzle and if you could tell me where to look I would add the functionality to the program in a moment :)