### PR TITLE
Fix ffi meta

### DIFF
--- a/meta/template/ffi.lua
+++ b/meta/template/ffi.lua
@@ -2,13 +2,17 @@
 ---@meta
 
 ---@class ffi.namespace*: table
+---@field [string] function
+
+---@class ffi.ctype*: userdata
+---@overload fun(init?: any, ...): ffi.cdata*
+---@overload fun(nelem?: integer, init?: any, ...): ffi.cdata*
+local ctype
 
 ---@class ffi.cdecl*: string
----@class ffi.ctype*: userdata
-local ctype
 ---@class ffi.cdata*: userdata
----@alias ffi.ct*     ffi.cdecl*|ffi.ctype*|ffi.cdata*
----@class ffi.cb*:    userdata
+---@alias ffi.ct*     ffi.ctype*|ffi.cdecl*|ffi.cdata*
+---@class ffi.cb*:    ffi.cdata*
 local cb
 ---@class ffi.VLA*:   userdata
 ---@class ffi.VLS*:   userdata
@@ -20,8 +24,9 @@ local cb
 ---@field arch string
 local ffi = {}
 
----@param def string
-function ffi.cdef(def) end
+---@param def     string
+---@param params? any
+function ffi.cdef(def, params, ...) end
 
 ---@param name    string
 ---@param global? boolean
@@ -29,6 +34,7 @@ function ffi.cdef(def) end
 ---@nodiscard
 function ffi.load(name, global) end
 
+---@overload fun(ct: ffi.ct*, init: any, ...)
 ---@param ct     ffi.ct*
 ---@param nelem? integer
 ---@param init?  any
@@ -36,19 +42,16 @@ function ffi.load(name, global) end
 ---@nodiscard
 function ffi.new(ct, nelem, init, ...) end
 
----@param nelem? integer
----@param init?  any
----@return ffi.cdata* cdata
-function ffi.ctype(nelem, init, ...) end
-
----@param ct ffi.ct*
+---@param ct      ffi.ct*
+---@param params? any
 ---@return ffi.ctype* ctype
 ---@nodiscard
-function ffi.typeof(ct) end
+function ffi.typeof(ct, params, ...) end
 
 ---@param ct   ffi.ct*
 ---@param init any
 ---@return ffi.cdata* cdata
+---@nodiscard
 function ffi.cast(ct, init) end
 
 ---@param ct        ffi.ct*


### PR DESCRIPTION
Fix some behavior in ffi meta 


---
```
---@field [string] function
```
1 - Fixes below issue when C functions are accessed from namespace tables.
![image](https://user-images.githubusercontent.com/38674984/200754540-e62429ff-acb4-4c91-8261-aaed4590a8e9.png)


---
```
---@overload fun(init?: any, ...): ffi.cdata*
---@overload fun(nelem?: integer, init?: any, ...): ffi.cdata*
```
2 - *`ctype`* isn't a function, it says that `ffi.ctype*` can be called like a constructor [(see Calling a cdata object section)](https://luajit.org/ext_ffi_semantics.html#cdata_call):
> **Calling a cdata object**
**Constructor**: a ctype object can be called and used as a [constructor](https://luajit.org/ext_ffi_api.html#ffi_new). This is equivalent to `ffi.new(ct, ...)`, unless a `__new` metamethod is defined.

![image](https://user-images.githubusercontent.com/38674984/200751333-d35067a3-f79b-4875-a105-1da6d9b3ea93.png)


---
```
---@class ffi.cb*:    ffi.cdata*
```
3 - `cb` types can only come from `ffi.new` or `ffi.cast`, e.g.: `ffi.cast('int (*)()', function() return 1 end)`

---
```---@param def     string
---@param params? any
function ffi.cdef(def, params, ...) end
```
4 - `ffi.cdef` and `ffi.typeof` accepts "parameters" for cdecls containing `$` [(see Parameterized Types section)](https://luajit.org/ext_ffi_semantics.html#param):
> Any place you can write a **`typedef` name**, an **identifier** or a **number** in a declaration, you can write `$` (the dollar sign) instead. These placeholders are replaced in order of appearance with the arguments following the cdecl string

![image](https://user-images.githubusercontent.com/38674984/200753751-aabeda09-585e-420c-b19d-30509ed80d2b.png)


---
```
---@overload fun(ct: ffi.ct*, init: any, ...)
```
5 - Prevent the following issue from happening (when `nelem` is skipped and `init` is meant to be specified):
![image](https://user-images.githubusercontent.com/38674984/200753236-007b1f4f-1df8-4e94-9bb8-6cb9fad9516d.png)


---
( Removal of `ffi.ctype` )
6 - see issue 2 above 


---
```
---@param params? any
---@return ffi.ctype* ctype
---@nodiscard
function ffi.typeof(ct, params, ...) end
```
7 - see issue 4 above


---
```
---@nodiscard
function ffi.cast(ct, init) end
```
8 - `---@nodiscard` is useful here because casts are always meant to be used in ffi.
