### PR TITLE
OpenResty: add plain integer type to ngx.http.status_code

### DIFF
--- a/meta/3rd/OpenResty/library/ngx.lua
+++ b/meta/3rd/OpenResty/library/ngx.lua
@@ -106,6 +106,7 @@ ngx.HTTP_VERSION_NOT_SUPPORTED  = 505
 ngx.HTTP_INSUFFICIENT_STORAGE   = 507
 
 ---@alias ngx.http.status_code
+---| integer
 ---| `ngx.HTTP_CONTINUE`
 ---| `ngx.HTTP_SWITCHING_PROTOCOLS`
 ---| `ngx.HTTP_OK`


### PR DESCRIPTION
:wave: small annotation update

---

Both of these are legal (and common in OpenResty code):

```lua
ngx.exit(ngx.HTTP_OK)
ngx.exit(200)
```