### PR TITLE
Add literal enum example to `@alias` documentation

### DIFF
--- a/locale/en-us/script.lua
+++ b/locale/en-us/script.lua
@@ -721,6 +721,20 @@ function find(path, pattern) end
 ---@param style font-style Style to apply
 function setFontStyle(style) end
 ```
+
+### Literal Enum
+```
+local enums = {
+    READ = 0,
+    WRITE = 1,
+    CLOSED = 2
+}
+
+---@alias FileStates
+---| `enums.READ`
+---| `enums.WRITE`
+---| `enums.CLOSE`
+```
 ---
 [View Wiki](https://github.com/sumneko/lua-language-server/wiki/Annotations#alias)
 ]=]

--- a/locale/pt-br/script.lua
+++ b/locale/pt-br/script.lua
@@ -721,6 +721,20 @@ function find(path, pattern) end
 ---@param style font-style Style to apply
 function setFontStyle(style) end
 ```
+
+### Literal Enum
+```
+local enums = {
+    READ = 0,
+    WRITE = 1,
+    CLOSED = 2
+}
+
+---@alias FileStates
+---| `enums.READ`
+---| `enums.WRITE`
+---| `enums.CLOSE`
+```
 ---
 [View Wiki](https://github.com/sumneko/lua-language-server/wiki/Annotations#alias)
 ]=]

--- a/locale/zh-cn/script.lua
+++ b/locale/zh-cn/script.lua
@@ -721,6 +721,20 @@ function find(path, pattern) end
 ---@param style font-style Style to apply
 function setFontStyle(style) end
 ```
+
+### Literal Enum
+```
+local enums = {
+    READ = 0,
+    WRITE = 1,
+    CLOSED = 2
+}
+
+---@alias FileStates
+---| `enums.READ`
+---| `enums.WRITE`
+---| `enums.CLOSE`
+```
 ---
 [View Wiki](https://github.com/sumneko/lua-language-server/wiki/Annotations#alias)
 ]=]

--- a/locale/zh-tw/script.lua
+++ b/locale/zh-tw/script.lua
@@ -721,6 +721,20 @@ function find(path, pattern) end
 ---@param style font-style Style to apply
 function setFontStyle(style) end
 ```
+
+### Literal Enum
+```
+local enums = {
+    READ = 0,
+    WRITE = 1,
+    CLOSED = 2
+}
+
+---@alias FileStates
+---| `enums.READ`
+---| `enums.WRITE`
+---| `enums.CLOSE`
+```
 ---
 [檢視文件](https://github.com/sumneko/lua-language-server/wiki/Annotations#alias)
 ]=]


### PR DESCRIPTION
Adds literal enum example to `@alias` documentation in English for all languages.

Closes #1685