### PR TITLE
Fix validation in CLI if diagnostics.severity contains ...! settings

### DIFF
--- a/script/cli/check.lua
+++ b/script/cli/check.lua
@@ -53,6 +53,9 @@ lclient():start(function (client)
     local disables = util.arrayToHash(config.get(rootUri, 'Lua.diagnostics.disable'))
     for name, serverity in pairs(define.DiagnosticDefaultSeverity) do
         serverity = config.get(rootUri, 'Lua.diagnostics.severity')[name] or 'Warning'
+        if serverity:sub(-1) == '!' then
+            serverity = serverity:sub(1, -2)
+        end
         if define.DiagnosticSeverity[serverity] > checkLevel then
             disables[name] = true
         end


### PR DESCRIPTION
Seems that I have found some bug while trying to use command line for validation.

My settings in  .luarc.json is like this:

```
{
    "diagnostics.enable": true,
    "diagnostics.groupSeverity": {
        "global": "Error",
        "strong": "Error",
        "type-check": "Error",
        "unused": "Error"
    },
    "diagnostics.severity": {
        "spell-check": "Information!",
        "trailing-space": "Information!",
        "duplicate-doc-alias": "Information!",
    },
    "runtime.version": "Lua 5.1",
    ...
}
```

And when I try to start validation I get errors:

```
script\cli\check.lua:56: attempt to compare number with nil
stack traceback:
 script\cli\check.lua:56: in upvalue 'callback'
 script\lclient.lua:101: in function <script\lclient.lua:100>
stack traceback:
 script\lclient.lua:95: in function 'await.errorHandle'
 script\await.lua:35: in function 'await.checkResult'
 (...tail calls...)
 script\workspace\workspace.lua:512: in function 'workspace.workspace.awaitReload'
 script\workspace\workspace.lua:453: in function <script\workspace\workspace.lua:452>
script\lclient.lua:96: [18:48:22.465][error][#0:script\lclient.lua:95]: script\cli\check.lua:56: attempt to compare number with nil
stack traceback:
 script\cli\check.lua:56: in upvalue 'callback'
 script\lclient.lua:101: in function <script\lclient.lua:100>
stack traceback:
 script\lclient.lua:95: in function 'await.errorHandle'
 script\await.lua:35: in function 'await.checkResult'
 (...tail calls...)
 script\workspace\workspace.lua:512: in function 'workspace.workspace.awaitReload'
 script\workspace\workspace.lua:453: in function <script\workspace\workspace.lua:452>
stack traceback:
 [C]: in function 'error'
 script\lclient.lua:96: in function 'await.errorHandle'
 script\await.lua:35: in function 'await.checkResult'
 (...tail calls...)
 script\workspace\workspace.lua:512: in function 'workspace.workspace.awaitReload'
 script\workspace\workspace.lua:453: in function <script\workspace\workspace.lua:452>
stack traceback:
 script\lclient.lua:95: in function 'await.errorHandle'
 script\await.lua:35: in function 'await.checkResult'
 (...tail calls...)
 script\await.lua:213: in function 'await.step'
 script\lclient.lua:112: in method 'start'
 script\cli\check.lua:38: in main chunk
 [C]: in function 'require'
 script\cli\init.lua:7: in main chunk
 [C]: in function 'require'
 D:/Repos/lua_language_server/app\main.lua:73: in main chunk
 D:/Repos/lua_language_server/app/bin/main.lua:85: in main chunk
 [C]: in ?
D:\Repos\lua_language_server\app\bin\lua-language-server.exe: script\lclient.lua:96: [18:48:22.465][error][#0:script\lclient.lua:95]: script\lclient.lua:96: [18:48:22.465][error][#0:script\lclient.lua:95]: script\cli\check.lua:56: attempt to compare number with nil
stack traceback:
 script\cli\check.lua:56: in upvalue 'callback'
 script\lclient.lua:101: in function <script\lclient.lua:100>
stack traceback:
 script\lclient.lua:95: in function 'await.errorHandle'
 script\await.lua:35: in function 'await.checkResult'
 (...tail calls...)
 script\workspace\workspace.lua:512: in function 'workspace.workspace.awaitReload'
 script\workspace\workspace.lua:453: in function <script\workspace\workspace.lua:452>
stack traceback:
 [C]: in function 'error'
 script\lclient.lua:96: in function 'await.errorHandle'
 script\await.lua:35: in function 'await.checkResult'
 (...tail calls...)
 script\workspace\workspace.lua:512: in function 'workspace.workspace.awaitReload'
 script\workspace\workspace.lua:453: in function <script\workspace\workspace.lua:452>
stack traceback:
 script\lclient.lua:95: in function 'await.errorHandle'
 script\await.lua:35: in function 'await.checkResult'
 (...tail calls...)
 script\await.lua:213: in function 'await.step'
 script\lclient.lua:112: in method 'start'
 script\cli\check.lua:38: in main chunk
 [C]: in function 'require'
 script\cli\init.lua:7: in main chunk
 [C]: in function 'require'
 D:/Repos/lua_language_server/app\main.lua:73: in main chunk
 D:/Repos/lua_language_server/app/bin/main.lua:85: in main chunk
 [C]: in ?
stack traceback:
 [C]: in function 'error'
 script\lclient.lua:96: in function 'await.errorHandle'
 script\await.lua:35: in function 'await.checkResult'
 (...tail calls...)
 script\await.lua:213: in function 'await.step'
 script\lclient.lua:112: in method 'start'
 script\cli\check.lua:38: in main chunk
 [C]: in function 'require'
 script\cli\init.lua:7: in main chunk
 [C]: in function 'require'
 D:/Repos/lua_language_server/app\main.lua:73: in main chunk
 D:/Repos/lua_language_server/app/bin/main.lua:85: in main chunk
 [C]: in ?
```

If I remove exclamation mark in "diagnostics.severity" settings (replace "Information!" -> "Information") validation passes without errors but in this case language server mode does not override group warning settings and I get errors instead of informations. But I want to use "diagnostics.severity" with exclamation mark in both modes without errors... 

This PR should fix this problem