### PR TITLE
Added links to all love2d functions in documentation

### DIFF
--- a/meta/3rd/love2d/library/love/audio.lua
+++ b/meta/3rd/love2d/library/love/audio.lua
@@ -3,11 +3,17 @@
 ---
 ---Provides an interface to create noise with the user's speakers.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio)
+---
 ---@class love.audio
 love.audio = {}
 
 ---
 ---Gets a list of the names of the currently enabled effects.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.getActiveEffects)
 ---
 ---@return table effects # The list of the names of the currently enabled effects.
 function love.audio.getActiveEffects() end
@@ -15,11 +21,17 @@ function love.audio.getActiveEffects() end
 ---
 ---Gets the current number of simultaneously playing sources.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.getActiveSourceCount)
+---
 ---@return number count # The current number of simultaneously playing sources.
 function love.audio.getActiveSourceCount() end
 
 ---
 ---Returns the distance attenuation model.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.getDistanceModel)
 ---
 ---@return love.DistanceModel model # The current distance model. The default is 'inverseclamped'.
 function love.audio.getDistanceModel() end
@@ -27,11 +39,17 @@ function love.audio.getDistanceModel() end
 ---
 ---Gets the current global scale factor for velocity-based doppler effects.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.getDopplerScale)
+---
 ---@return number scale # The current doppler scale factor.
 function love.audio.getDopplerScale() end
 
 ---
 ---Gets the settings associated with an effect.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.getEffect)
 ---
 ---@param name string # The name of the effect.
 ---@return table settings # The settings associated with the effect.
@@ -40,17 +58,26 @@ function love.audio.getEffect(name) end
 ---
 ---Gets the maximum number of active effects supported by the system.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.getMaxSceneEffects)
+---
 ---@return number maximum # The maximum number of active effects.
 function love.audio.getMaxSceneEffects() end
 
 ---
 ---Gets the maximum number of active Effects in a single Source object, that the system can support.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.getMaxSourceEffects)
+---
 ---@return number maximum # The maximum number of active Effects per Source.
 function love.audio.getMaxSourceEffects() end
 
 ---
 ---Returns the orientation of the listener.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.getOrientation)
 ---
 ---@return number fx # Forward vector of the listener orientation.
 ---@return number fy # Forward vector of the listener orientation.
@@ -62,6 +89,9 @@ function love.audio.getOrientation() end
 
 ---
 ---Returns the position of the listener. Please note that positional audio only works for mono (i.e. non-stereo) sources.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.getPosition)
 ---
 ---@return number x # The X position of the listener.
 ---@return number y # The Y position of the listener.
@@ -75,17 +105,26 @@ function love.audio.getPosition() end
 ---
 ---Audio recording is currently not supported on iOS.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.getRecordingDevices)
+---
 ---@return table devices # The list of connected recording devices.
 function love.audio.getRecordingDevices() end
 
 ---
 ---Gets the current number of simultaneously playing sources.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.getSourceCount)
+---
 ---@return number numSources # The current number of simultaneously playing sources.
 function love.audio.getSourceCount() end
 
 ---
 ---Returns the velocity of the listener.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.getVelocity)
 ---
 ---@return number x # The X velocity of the listener.
 ---@return number y # The Y velocity of the listener.
@@ -95,17 +134,26 @@ function love.audio.getVelocity() end
 ---
 ---Returns the master volume.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.getVolume)
+---
 ---@return number volume # The current master volume
 function love.audio.getVolume() end
 
 ---
 ---Gets whether audio effects are supported in the system.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.isEffectsSupported)
+---
 ---@return boolean supported # True if effects are supported, false otherwise.
 function love.audio.isEffectsSupported() end
 
 ---
 ---Creates a new Source usable for real-time generated sound playback with Source:queue.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.newQueueableSource)
 ---
 ---@param samplerate number # Number of samples per second when playing.
 ---@param bitdepth number # Bits per sample (8 or 16).
@@ -119,6 +167,9 @@ function love.audio.newQueueableSource(samplerate, bitdepth, channels, buffercou
 ---
 ---Sources created from SoundData are always static.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.newSource)
+---
 ---@overload fun(file: love.File, type: love.SourceType):love.Source
 ---@overload fun(decoder: love.Decoder, type: love.SourceType):love.Source
 ---@overload fun(data: love.FileData, type: love.SourceType):love.Source
@@ -131,6 +182,9 @@ function love.audio.newSource(filename, type) end
 ---
 ---Pauses specific or all currently played Sources.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.pause)
+---
 ---@overload fun(source: love.Source, ...)
 ---@overload fun(sources: table)
 ---@return table Sources # A table containing a list of Sources that were paused by this call.
@@ -138,6 +192,9 @@ function love.audio.pause() end
 
 ---
 ---Plays the specified Source.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.play)
 ---
 ---@overload fun(sources: table)
 ---@overload fun(source1: love.Source, source2: love.Source, ...)
@@ -147,11 +204,17 @@ function love.audio.play(source) end
 ---
 ---Sets the distance attenuation model.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.setDistanceModel)
+---
 ---@param model love.DistanceModel # The new distance model.
 function love.audio.setDistanceModel(model) end
 
 ---
 ---Sets a global scale factor for velocity-based doppler effects. The default scale value is 1.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.setDopplerScale)
 ---
 ---@param scale number # The new doppler scale factor. The scale must be greater than 0.
 function love.audio.setDopplerScale(scale) end
@@ -160,6 +223,9 @@ function love.audio.setDopplerScale(scale) end
 ---Defines an effect that can be applied to a Source.
 ---
 ---Not all system supports audio effects. Use love.audio.isEffectsSupported to check.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.setEffect)
 ---
 ---@overload fun(name: string, enabled?: boolean):boolean
 ---@param name string # The name of the effect.
@@ -170,12 +236,18 @@ function love.audio.setEffect(name, settings) end
 ---
 ---Sets whether the system should mix the audio with the system's audio.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.setMixWithSystem)
+---
 ---@param mix boolean # True to enable mixing, false to disable it.
 ---@return boolean success # True if the change succeeded, false otherwise.
 function love.audio.setMixWithSystem(mix) end
 
 ---
 ---Sets the orientation of the listener.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.setOrientation)
 ---
 ---@param fx number # Forward vector of the listener orientation.
 ---@param fy number # Forward vector of the listener orientation.
@@ -188,6 +260,9 @@ function love.audio.setOrientation(fx, fy, fz, ux, uy, uz) end
 ---
 ---Sets the position of the listener, which determines how sounds play.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.setPosition)
+---
 ---@param x number # The x position of the listener.
 ---@param y number # The y position of the listener.
 ---@param z number # The z position of the listener.
@@ -195,6 +270,9 @@ function love.audio.setPosition(x, y, z) end
 
 ---
 ---Sets the velocity of the listener.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.setVelocity)
 ---
 ---@param x number # The X velocity of the listener.
 ---@param y number # The Y velocity of the listener.
@@ -204,11 +282,17 @@ function love.audio.setVelocity(x, y, z) end
 ---
 ---Sets the master volume.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.setVolume)
+---
 ---@param volume number # 1.0 is max and 0.0 is off.
 function love.audio.setVolume(volume) end
 
 ---
 ---Stops currently played sources.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio.stop)
 ---
 ---@overload fun(source: love.Source)
 ---@overload fun(source1: love.Source, source2: love.Source, ...)
@@ -218,17 +302,26 @@ function love.audio.stop() end
 ---
 ---Represents an audio input device capable of recording sounds.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio)
+---
 ---@class love.RecordingDevice: love.Object
 local RecordingDevice = {}
 
 ---
 ---Gets the number of bits per sample in the data currently being recorded.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RecordingDevice:getBitDepth)
+---
 ---@return number bits # The number of bits per sample in the data that's currently being recorded.
 function RecordingDevice:getBitDepth() end
 
 ---
 ---Gets the number of channels currently being recorded (mono or stereo).
+---
+---
+---[Open in Browser](https://love2d.org/wiki/RecordingDevice:getChannelCount)
 ---
 ---@return number channels # The number of channels being recorded (1 for mono, 2 for stereo).
 function RecordingDevice:getChannelCount() end
@@ -238,11 +331,17 @@ function RecordingDevice:getChannelCount() end
 ---
 ---The internal ring buffer is cleared when this function is called, so calling it again will only get audio recorded after the previous call. If the device's internal ring buffer completely fills up before getData is called, the oldest data that doesn't fit into the buffer will be lost.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RecordingDevice:getData)
+---
 ---@return love.SoundData data # The recorded audio data, or nil if the device isn't recording.
 function RecordingDevice:getData() end
 
 ---
 ---Gets the name of the recording device.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/RecordingDevice:getName)
 ---
 ---@return string name # The name of the device.
 function RecordingDevice:getName() end
@@ -250,11 +349,17 @@ function RecordingDevice:getName() end
 ---
 ---Gets the number of currently recorded samples.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RecordingDevice:getSampleCount)
+---
 ---@return number samples # The number of samples that have been recorded so far.
 function RecordingDevice:getSampleCount() end
 
 ---
 ---Gets the number of samples per second currently being recorded.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/RecordingDevice:getSampleRate)
 ---
 ---@return number rate # The number of samples being recorded per second (sample rate).
 function RecordingDevice:getSampleRate() end
@@ -262,11 +367,17 @@ function RecordingDevice:getSampleRate() end
 ---
 ---Gets whether the device is currently recording.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RecordingDevice:isRecording)
+---
 ---@return boolean recording # True if the recording, false otherwise.
 function RecordingDevice:isRecording() end
 
 ---
 ---Begins recording audio using this device.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/RecordingDevice:start)
 ---
 ---@param samplecount number # The maximum number of samples to store in an internal ring buffer when recording. RecordingDevice:getData clears the internal buffer when called.
 ---@param samplerate? number # The number of samples per second to store when recording.
@@ -278,6 +389,9 @@ function RecordingDevice:start(samplecount, samplerate, bitdepth, channels) end
 ---
 ---Stops recording audio from this device. Any sound data currently in the device's buffer will be returned.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RecordingDevice:stop)
+---
 ---@return love.SoundData data # The sound data currently in the device's buffer, or nil if the device wasn't recording.
 function RecordingDevice:stop() end
 
@@ -288,6 +402,9 @@ function RecordingDevice:stop() end
 ---
 ---The Source controls (play/pause/stop) act according to the following state table.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.audio)
+---
 ---@class love.Source: love.Object
 local Source = {}
 
@@ -296,11 +413,17 @@ local Source = {}
 ---
 ---Static Sources will use significantly less memory and take much less time to be created if Source:clone is used to create them instead of love.audio.newSource, so this method should be preferred when making multiple Sources which play the same sound.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:clone)
+---
 ---@return love.Source source # The new identical copy of this Source.
 function Source:clone() end
 
 ---
 ---Gets a list of the Source's active effect names.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:getActiveEffects)
 ---
 ---@return table effects # A list of the source's active effect names.
 function Source:getActiveEffects() end
@@ -310,11 +433,17 @@ function Source:getActiveEffects() end
 ---
 ---By default the value is set to 0 which means that air absorption effects are disabled. A value of 1 will apply high frequency attenuation to the Source at a rate of 0.05 dB per meter.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:getAirAbsorption)
+---
 ---@return number amount # The amount of air absorption applied to the Source.
 function Source:getAirAbsorption() end
 
 ---
 ---Gets the reference and maximum attenuation distances of the Source. The values, combined with the current DistanceModel, affect how the Source's volume attenuates based on distance from the listener.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:getAttenuationDistances)
 ---
 ---@return number ref # The current reference attenuation distance. If the current DistanceModel is clamped, this is the minimum distance before the Source is no longer attenuated.
 ---@return number max # The current maximum attenuation distance.
@@ -323,11 +452,17 @@ function Source:getAttenuationDistances() end
 ---
 ---Gets the number of channels in the Source. Only 1-channel (mono) Sources can use directional and positional effects.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:getChannelCount)
+---
 ---@return number channels # 1 for mono, 2 for stereo.
 function Source:getChannelCount() end
 
 ---
 ---Gets the Source's directional volume cones. Together with Source:setDirection, the cone angles allow for the Source's volume to vary depending on its direction.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:getCone)
 ---
 ---@return number innerAngle # The inner angle from the Source's direction, in radians. The Source will play at normal volume if the listener is inside the cone defined by this angle.
 ---@return number outerAngle # The outer angle from the Source's direction, in radians. The Source will play at a volume between the normal and outer volumes, if the listener is in between the cones defined by the inner and outer angles.
@@ -337,6 +472,9 @@ function Source:getCone() end
 ---
 ---Gets the direction of the Source.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:getDirection)
+---
 ---@return number x # The X part of the direction vector.
 ---@return number y # The Y part of the direction vector.
 ---@return number z # The Z part of the direction vector.
@@ -344,6 +482,9 @@ function Source:getDirection() end
 
 ---
 ---Gets the duration of the Source. For streaming Sources it may not always be sample-accurate, and may return -1 if the duration cannot be determined at all.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:getDuration)
 ---
 ---@param unit? love.TimeUnit # The time unit for the return value.
 ---@return number duration # The duration of the Source, or -1 if it cannot be determined.
@@ -354,6 +495,9 @@ function Source:getDuration(unit) end
 ---
 ---This function returns nil if the effect was applied with no filter settings associated to it.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:getEffect)
+---
 ---@param name string # The name of the effect.
 ---@param filtersettings table # An optional empty table that will be filled with the filter settings.
 ---@return {volume: number, highgain: number, lowgain: number} filtersettings # The settings for the filter associated to this effect, or nil if the effect is not present in this Source or has no filter associated. The table has the following fields:
@@ -362,11 +506,17 @@ function Source:getEffect(name, filtersettings) end
 ---
 ---Gets the filter settings currently applied to the Source.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:getFilter)
+---
 ---@return {type: love.FilterType, volume: number, highgain: number, lowgain: number} settings # The filter settings to use for this Source, or nil if the Source has no active filter. The table has the following fields:
 function Source:getFilter() end
 
 ---
 ---Gets the number of free buffer slots in a queueable Source. If the queueable Source is playing, this value will increase up to the amount the Source was created with. If the queueable Source is stopped, it will process all of its internal buffers first, in which case this function will always return the amount it was created with.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:getFreeBufferCount)
 ---
 ---@return number buffers # How many more SoundData objects can be queued up.
 function Source:getFreeBufferCount() end
@@ -374,11 +524,17 @@ function Source:getFreeBufferCount() end
 ---
 ---Gets the current pitch of the Source.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:getPitch)
+---
 ---@return number pitch # The pitch, where 1.0 is normal.
 function Source:getPitch() end
 
 ---
 ---Gets the position of the Source.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:getPosition)
 ---
 ---@return number x # The X position of the Source.
 ---@return number y # The Y position of the Source.
@@ -388,17 +544,26 @@ function Source:getPosition() end
 ---
 ---Returns the rolloff factor of the source.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:getRolloff)
+---
 ---@return number rolloff # The rolloff factor.
 function Source:getRolloff() end
 
 ---
 ---Gets the type of the Source.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:getType)
+---
 ---@return love.SourceType sourcetype # The type of the source.
 function Source:getType() end
 
 ---
 ---Gets the velocity of the Source.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:getVelocity)
 ---
 ---@return number x # The X part of the velocity vector.
 ---@return number y # The Y part of the velocity vector.
@@ -408,11 +573,17 @@ function Source:getVelocity() end
 ---
 ---Gets the current volume of the Source.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:getVolume)
+---
 ---@return number volume # The volume of the Source, where 1.0 is normal volume.
 function Source:getVolume() end
 
 ---
 ---Returns the volume limits of the source.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:getVolumeLimits)
 ---
 ---@return number min # The minimum volume.
 ---@return number max # The maximum volume.
@@ -421,11 +592,17 @@ function Source:getVolumeLimits() end
 ---
 ---Returns whether the Source will loop.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:isLooping)
+---
 ---@return boolean loop # True if the Source will loop, false otherwise.
 function Source:isLooping() end
 
 ---
 ---Returns whether the Source is playing.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:isPlaying)
 ---
 ---@return boolean playing # True if the Source is playing, false otherwise.
 function Source:isPlaying() end
@@ -433,16 +610,25 @@ function Source:isPlaying() end
 ---
 ---Gets whether the Source's position, velocity, direction, and cone angles are relative to the listener.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:isRelative)
+---
 ---@return boolean relative # True if the position, velocity, direction and cone angles are relative to the listener, false if they're absolute.
 function Source:isRelative() end
 
 ---
 ---Pauses the Source.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:pause)
+---
 function Source:pause() end
 
 ---
 ---Starts playing the Source.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:play)
 ---
 ---@return boolean success # Whether the Source was able to successfully start playing.
 function Source:play() end
@@ -452,12 +638,18 @@ function Source:play() end
 ---
 ---This method requires the Source to be created via love.audio.newQueueableSource.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:queue)
+---
 ---@param sounddata love.SoundData # The data to queue. The SoundData's sample rate, bit depth, and channel count must match the Source's.
 ---@return boolean success # True if the data was successfully queued for playback, false if there were no available buffers to use for queueing.
 function Source:queue(sounddata) end
 
 ---
 ---Sets the currently playing position of the Source.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:seek)
 ---
 ---@param offset number # The position to seek to.
 ---@param unit? love.TimeUnit # The unit of the position value.
@@ -470,6 +662,9 @@ function Source:seek(offset, unit) end
 ---
 ---Air absorption can simulate sound transmission through foggy air, dry air, smoky atmosphere, etc. It can be used to simulate different atmospheric conditions within different locations in an area.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:setAirAbsorption)
+---
 ---@param amount number # The amount of air absorption applied to the Source. Must be between 0 and 10.
 function Source:setAirAbsorption(amount) end
 
@@ -478,12 +673,18 @@ function Source:setAirAbsorption(amount) end
 ---
 ---Distance attenuation is only applicable to Sources based on mono (rather than stereo) audio.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:setAttenuationDistances)
+---
 ---@param ref number # The new reference attenuation distance. If the current DistanceModel is clamped, this is the minimum attenuation distance.
 ---@param max number # The new maximum attenuation distance.
 function Source:setAttenuationDistances(ref, max) end
 
 ---
 ---Sets the Source's directional volume cones. Together with Source:setDirection, the cone angles allow for the Source's volume to vary depending on its direction.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:setCone)
 ---
 ---@param innerAngle number # The inner angle from the Source's direction, in radians. The Source will play at normal volume if the listener is inside the cone defined by this angle.
 ---@param outerAngle number # The outer angle from the Source's direction, in radians. The Source will play at a volume between the normal and outer volumes, if the listener is in between the cones defined by the inner and outer angles.
@@ -492,6 +693,9 @@ function Source:setCone(innerAngle, outerAngle, outerVolume) end
 
 ---
 ---Sets the direction vector of the Source. A zero vector makes the source non-directional.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:setDirection)
 ---
 ---@param x number # The X part of the direction vector.
 ---@param y number # The Y part of the direction vector.
@@ -503,6 +707,9 @@ function Source:setDirection(x, y, z) end
 ---
 ---The effect must have been previously defined using love.audio.setEffect.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:setEffect)
+---
 ---@overload fun(self: love.Source, name: string, filtersettings: table):boolean
 ---@param name string # The name of the effect previously set up with love.audio.setEffect.
 ---@param enable? boolean # If false and the given effect name was previously enabled on this Source, disables the effect.
@@ -512,6 +719,9 @@ function Source:setEffect(name, enable) end
 ---
 ---Sets a low-pass, high-pass, or band-pass filter to apply when playing the Source.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:setFilter)
+---
 ---@overload fun(self: love.Source)
 ---@param settings {type: love.FilterType, volume: number, highgain: number, lowgain: number} # The filter settings to use for this Source, with the following fields:
 ---@return boolean success # Whether the filter was successfully applied to the Source.
@@ -520,17 +730,26 @@ function Source:setFilter(settings) end
 ---
 ---Sets whether the Source should loop.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:setLooping)
+---
 ---@param loop boolean # True if the source should loop, false otherwise.
 function Source:setLooping(loop) end
 
 ---
 ---Sets the pitch of the Source.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:setPitch)
+---
 ---@param pitch number # Calculated with regard to 1 being the base pitch. Each reduction by 50 percent equals a pitch shift of -12 semitones (one octave reduction). Each doubling equals a pitch shift of 12 semitones (one octave increase). Zero is not a legal value.
 function Source:setPitch(pitch) end
 
 ---
 ---Sets the position of the Source. Please note that this only works for mono (i.e. non-stereo) sound files!
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:setPosition)
 ---
 ---@param x number # The X position of the Source.
 ---@param y number # The Y position of the Source.
@@ -542,6 +761,9 @@ function Source:setPosition(x, y, z) end
 ---
 ---By default, all sources are absolute and therefore relative to the origin of love's coordinate system 0, 0. Only absolute sources are affected by the position of the listener. Please note that positional audio only works for mono (i.e. non-stereo) sources. 
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:setRelative)
+---
 ---@param enable? boolean # True to make the position, velocity, direction and cone angles relative to the listener, false to make them absolute.
 function Source:setRelative(enable) end
 
@@ -549,6 +771,9 @@ function Source:setRelative(enable) end
 ---Sets the rolloff factor which affects the strength of the used distance attenuation.
 ---
 ---Extended information and detailed formulas can be found in the chapter '3.4. Attenuation By Distance' of OpenAL 1.1 specification.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:setRolloff)
 ---
 ---@param rolloff number # The new rolloff factor.
 function Source:setRolloff(rolloff) end
@@ -558,6 +783,9 @@ function Source:setRolloff(rolloff) end
 ---
 ---This does '''not''' change the position of the Source, but lets the application know how it has to calculate the doppler effect.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:setVelocity)
+---
 ---@param x number # The X part of the velocity vector.
 ---@param y number # The Y part of the velocity vector.
 ---@param z number # The Z part of the velocity vector.
@@ -566,11 +794,17 @@ function Source:setVelocity(x, y, z) end
 ---
 ---Sets the current volume of the Source.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:setVolume)
+---
 ---@param volume number # The volume for a Source, where 1.0 is normal volume. Volume cannot be raised above 1.0.
 function Source:setVolume(volume) end
 
 ---
 ---Sets the volume limits of the source. The limits have to be numbers from 0 to 1.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:setVolumeLimits)
 ---
 ---@param min number # The minimum volume.
 ---@param max number # The maximum volume.
@@ -579,10 +813,16 @@ function Source:setVolumeLimits(min, max) end
 ---
 ---Stops a Source.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:stop)
+---
 function Source:stop() end
 
 ---
 ---Gets the currently playing position of the Source.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Source:tell)
 ---
 ---@param unit? love.TimeUnit # The type of unit for the return value.
 ---@return number position # The currently playing position of the Source.
@@ -592,6 +832,9 @@ function Source:tell(unit) end
 ---The different distance models.
 ---
 ---Extended information can be found in the chapter "3.4. Attenuation By Distance" of the OpenAL 1.1 specification.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/DistanceModel)
 ---
 ---@alias love.DistanceModel
 ---
@@ -625,6 +868,9 @@ function Source:tell(unit) end
 
 ---
 ---The different types of effects supported by love.audio.setEffect.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/EffectType)
 ---
 ---@alias love.EffectType
 ---
@@ -663,6 +909,9 @@ function Source:tell(unit) end
 ---
 ---The different types of waveforms that can be used with the '''ringmodulator''' EffectType.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/EffectWaveform)
+---
 ---@alias love.EffectWaveform
 ---
 ---A sawtooth wave, also known as a ramp wave. Named for its linear rise, and (near-)instantaneous fall along time.
@@ -684,6 +933,9 @@ function Source:tell(unit) end
 ---
 ---Types of filters for Sources.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/FilterType)
+---
 ---@alias love.FilterType
 ---
 ---Low-pass filter. High frequency sounds are attenuated.
@@ -703,6 +955,9 @@ function Source:tell(unit) end
 ---
 ---A good rule of thumb is to use stream for music files and static for all short sound effects. Basically, you want to avoid loading large files into memory at once.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/SourceType)
+---
 ---@alias love.SourceType
 ---
 ---The whole audio is decoded.
@@ -719,6 +974,9 @@ function Source:tell(unit) end
 
 ---
 ---Units that represent time.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/TimeUnit)
 ---
 ---@alias love.TimeUnit
 ---

--- a/meta/3rd/love2d/library/love/data.lua
+++ b/meta/3rd/love2d/library/love/data.lua
@@ -3,11 +3,17 @@
 ---
 ---Provides functionality for creating and transforming data.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.data)
+---
 ---@class love.data
 love.data = {}
 
 ---
 ---Compresses a string or data using a specific compression algorithm.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.data.compress)
 ---
 ---@overload fun(container: love.ContainerType, format: love.CompressedDataFormat, data: love.Data, level?: number):love.CompressedData|string
 ---@param container love.ContainerType # What type to return the compressed data as.
@@ -20,6 +26,9 @@ function love.data.compress(container, format, rawstring, level) end
 ---
 ---Decode Data or a string from any of the EncodeFormats to Data or string.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.data.decode)
+---
 ---@overload fun(container: love.ContainerType, format: love.EncodeFormat, sourceData: love.Data):love.ByteData|string
 ---@param container love.ContainerType # What type to return the decoded data as.
 ---@param format love.EncodeFormat # The format of the input data.
@@ -30,6 +39,9 @@ function love.data.decode(container, format, sourceString) end
 ---
 ---Decompresses a CompressedData or previously compressed string or Data object.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.data.decompress)
+---
 ---@overload fun(container: love.ContainerType, format: love.CompressedDataFormat, compressedString: string):love.Data|string
 ---@overload fun(container: love.ContainerType, format: love.CompressedDataFormat, data: love.Data):love.Data|string
 ---@param container love.ContainerType # What type to return the decompressed data as.
@@ -39,6 +51,9 @@ function love.data.decompress(container, compressedData) end
 
 ---
 ---Encode Data or a string to a Data or string in one of the EncodeFormats.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.data.encode)
 ---
 ---@overload fun(container: love.ContainerType, format: love.EncodeFormat, sourceData: love.Data, linelength?: number):love.ByteData|string
 ---@param container love.ContainerType # What type to return the encoded data as.
@@ -53,12 +68,18 @@ function love.data.encode(container, format, sourceString, linelength) end
 ---
 ---This function behaves the same as Lua 5.3's string.packsize.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.data.getPackedSize)
+---
 ---@param format string # A string determining how the values are packed. Follows the rules of Lua 5.3's string.pack format strings.
 ---@return number size # The size in bytes that the packed data will use.
 function love.data.getPackedSize(format) end
 
 ---
 ---Compute the message digest of a string using a specified hash algorithm.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.data.hash)
 ---
 ---@overload fun(hashFunction: love.HashFunction, data: love.Data):string
 ---@param hashFunction love.HashFunction # Hash algorithm to use.
@@ -71,6 +92,9 @@ function love.data.hash(hashFunction, string) end
 ---
 ---Data:getPointer along with LuaJIT's FFI can be used to manipulate the contents of the ByteData object after it has been created.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.data.newByteData)
+---
 ---@overload fun(Data: love.Data, offset?: number, size?: number):love.ByteData
 ---@overload fun(size: number):love.ByteData
 ---@param datastring string # The byte string to copy.
@@ -79,6 +103,9 @@ function love.data.newByteData(datastring) end
 
 ---
 ---Creates a new Data referencing a subsection of an existing Data object.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.data.newDataView)
 ---
 ---@param data love.Data # The Data object to reference.
 ---@param offset number # The offset of the subsection to reference, in bytes.
@@ -91,6 +118,9 @@ function love.data.newDataView(data, offset, size) end
 ---
 ---This function behaves the same as Lua 5.3's string.pack.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.data.pack)
+---
 ---@param container love.ContainerType # What type to return the encoded data as.
 ---@param format string # A string determining how the values are packed. Follows the rules of Lua 5.3's string.pack format strings.
 ---@param v1 number|boolean|string # The first value (number, boolean, or string) to serialize.
@@ -102,6 +132,9 @@ function love.data.pack(container, format, v1, ...) end
 ---Unpacks (deserializes) a byte-string or Data into simple Lua values.
 ---
 ---This function behaves the same as Lua 5.3's string.unpack.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.data.unpack)
 ---
 ---@overload fun(format: string, data: love.Data, pos?: number):number|boolean|string, number|boolean|string, number
 ---@param format string # A string determining how the values were packed. Follows the rules of Lua 5.3's string.pack format strings.
@@ -116,6 +149,9 @@ function love.data.unpack(format, datastring, pos) end
 ---
 ---There are currently no LÖVE functions provided for manipulating the contents of a ByteData, but Data:getPointer can be used with LuaJIT's FFI to access and write to the contents directly.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.data)
+---
 ---@class love.ByteData: love.Object, love.Data
 local ByteData = {}
 
@@ -124,17 +160,26 @@ local ByteData = {}
 ---
 ---love.data.decompress can be used to de-compress the data (or love.math.decompress in 0.10.2 or earlier).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.data)
+---
 ---@class love.CompressedData: love.Data, love.Object
 local CompressedData = {}
 
 ---
 ---Gets the compression format of the CompressedData.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/CompressedData:getFormat)
+---
 ---@return love.CompressedDataFormat format # The format of the CompressedData.
 function CompressedData:getFormat() end
 
 ---
 ---Compressed data formats.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/CompressedDataFormat)
 ---
 ---@alias love.CompressedDataFormat
 ---
@@ -157,6 +202,9 @@ function CompressedData:getFormat() end
 ---
 ---Return type of various data-returning functions.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ContainerType)
+---
 ---@alias love.ContainerType
 ---
 ---Return type is ByteData.
@@ -170,6 +218,9 @@ function CompressedData:getFormat() end
 ---
 ---Encoding format used to encode or decode data.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/EncodeFormat)
+---
 ---@alias love.EncodeFormat
 ---
 ---Encode/decode data as base64 binary-to-text encoding.
@@ -182,6 +233,9 @@ function CompressedData:getFormat() end
 
 ---
 ---Hash algorithm of love.data.hash.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/HashFunction)
 ---
 ---@alias love.HashFunction
 ---

--- a/meta/3rd/love2d/library/love/event.lua
+++ b/meta/3rd/love2d/library/love/event.lua
@@ -3,16 +3,25 @@
 ---
 ---Manages events, like keypresses.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.event)
+---
 ---@class love.event
 love.event = {}
 
 ---
 ---Clears the event queue.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.event.clear)
+---
 function love.event.clear() end
 
 ---
 ---Returns an iterator for messages in the event queue.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.event.poll)
 ---
 ---@return function i # Iterator function usable in a for loop.
 function love.event.poll() end
@@ -26,12 +35,18 @@ function love.event.poll() end
 ---
 ---and if you want to handle OS-generated events at all (think callbacks).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.event.pump)
+---
 function love.event.pump() end
 
 ---
 ---Adds an event to the event queue.
 ---
 ---From 0.10.0 onwards, you may pass an arbitrary amount of arguments with this function, though the default callbacks don't ever use more than six.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.event.push)
 ---
 ---@param n love.Event # The name of the event.
 ---@param a? any # First event argument.
@@ -48,12 +63,18 @@ function love.event.push(n, a, b, c, d, e, f, ...) end
 ---
 ---The quit event is a signal for the event handler to close LÖVE. It's possible to abort the exit process with the love.quit callback.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.event.quit)
+---
 ---@overload fun('restart': string|'restart')
 ---@param exitstatus? number # The program exit status to use when closing the application.
 function love.event.quit(exitstatus) end
 
 ---
 ---Like love.event.poll(), but blocks until there is an event in the queue.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.event.wait)
 ---
 ---@return love.Event n # The name of event.
 ---@return any a # First event argument.
@@ -68,6 +89,9 @@ function love.event.wait() end
 ---Arguments to love.event.push() and the like.
 ---
 ---Since 0.8.0, event names are no longer abbreviated.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Event)
 ---
 ---@alias love.Event
 ---

--- a/meta/3rd/love2d/library/love/filesystem.lua
+++ b/meta/3rd/love2d/library/love/filesystem.lua
@@ -3,11 +3,17 @@
 ---
 ---Provides an interface to the user's filesystem.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem)
+---
 ---@class love.filesystem
 love.filesystem = {}
 
 ---
 ---Append data to an existing file.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.append)
 ---
 ---@overload fun(name: string, data: love.Data, size?: number):boolean, string
 ---@param name string # The name (and path) of the file.
@@ -20,6 +26,9 @@ function love.filesystem.append(name, data, size) end
 ---
 ---Gets whether love.filesystem follows symbolic links.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.areSymlinksEnabled)
+---
 ---@return boolean enable # Whether love.filesystem follows symbolic links.
 function love.filesystem.areSymlinksEnabled() end
 
@@ -28,12 +37,18 @@ function love.filesystem.areSymlinksEnabled() end
 ---
 ---When called with 'a/b' it creates both 'a' and 'a/b', if they don't exist already.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.createDirectory)
+---
 ---@param name string # The directory to create.
 ---@return boolean success # True if the directory was created, false if not.
 function love.filesystem.createDirectory(name) end
 
 ---
 ---Returns the application data directory (could be the same as getUserDirectory)
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.getAppdataDirectory)
 ---
 ---@return string path # The path of the application data directory
 function love.filesystem.getAppdataDirectory() end
@@ -45,6 +60,9 @@ function love.filesystem.getAppdataDirectory() end
 ---
 ---The paths are relative to the game's source and save directories, as well as any paths mounted with love.filesystem.mount.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.getCRequirePath)
+---
 ---@return string paths # The paths that the ''require'' function will check for c libraries in love's filesystem.
 function love.filesystem.getCRequirePath() end
 
@@ -52,6 +70,9 @@ function love.filesystem.getCRequirePath() end
 ---Returns a table with the names of files and subdirectories in the specified path. The table is not sorted in any way; the order is undefined.
 ---
 ---If the path passed to the function exists in the game and the save directory, it will list the files and directories from both places.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.getDirectoryItems)
 ---
 ---@overload fun(dir: string, callback: function):table
 ---@param dir string # The directory.
@@ -63,11 +84,17 @@ function love.filesystem.getDirectoryItems(dir) end
 ---
 ---Note that this only returns the name of the folder to store your files in, not the full path.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.getIdentity)
+---
 ---@return string name # The identity that is used as write directory.
 function love.filesystem.getIdentity() end
 
 ---
 ---Gets information about the specified file or directory.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.getInfo)
 ---
 ---@overload fun(path: string, info: table):table
 ---@overload fun(path: string, filtertype: love.FileType, info: table):table
@@ -81,6 +108,9 @@ function love.filesystem.getInfo(path, filtertype) end
 ---
 ---This can be used to determine whether a file is inside the save directory or the game's source .love.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.getRealDirectory)
+---
 ---@param filepath string # The filepath to get the directory of.
 ---@return string realdir # The platform-specific full path of the directory containing the filepath.
 function love.filesystem.getRealDirectory(filepath) end
@@ -92,6 +122,9 @@ function love.filesystem.getRealDirectory(filepath) end
 ---
 ---The paths are relative to the game's source and save directories, as well as any paths mounted with love.filesystem.mount.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.getRequirePath)
+---
 ---@return string paths # The paths that the ''require'' function will check in love's filesystem.
 function love.filesystem.getRequirePath() end
 
@@ -102,11 +135,17 @@ function love.filesystem.getRequirePath() end
 ---
 ---read or write in the save directory.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.getSaveDirectory)
+---
 ---@return string dir # The absolute path to the save directory.
 function love.filesystem.getSaveDirectory() end
 
 ---
 ---Returns the full path to the the .love file or directory. If the game is fused to the LÖVE executable, then the executable is returned.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.getSource)
 ---
 ---@return string path # The full platform-dependent path of the .love file or directory.
 function love.filesystem.getSource() end
@@ -116,11 +155,17 @@ function love.filesystem.getSource() end
 ---
 ---If love.filesystem.isFused is true, the path returned by this function can be passed to love.filesystem.mount, which will make the directory containing the main game (e.g. C:\Program Files\coolgame\) readable by love.filesystem.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.getSourceBaseDirectory)
+---
 ---@return string path # The full platform-dependent path of the directory containing the .love file.
 function love.filesystem.getSourceBaseDirectory() end
 
 ---
 ---Returns the path of the user's directory
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.getUserDirectory)
 ---
 ---@return string path # The path of the user's directory
 function love.filesystem.getUserDirectory() end
@@ -128,11 +173,17 @@ function love.filesystem.getUserDirectory() end
 ---
 ---Gets the current working directory.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.getWorkingDirectory)
+---
 ---@return string cwd # The current working directory.
 function love.filesystem.getWorkingDirectory() end
 
 ---
 ---Initializes love.filesystem, will be called internally, so should not be used explicitly.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.init)
 ---
 ---@param appname string # The name of the application binary, typically love.
 function love.filesystem.init(appname) end
@@ -144,11 +195,17 @@ function love.filesystem.init(appname) end
 ---
 ---A game is in fused mode if the source .love has been fused to the executable (see Game Distribution), or if '--fused' has been given as a command-line argument when starting the game.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.isFused)
+---
 ---@return boolean fused # True if the game is in fused mode, false otherwise.
 function love.filesystem.isFused() end
 
 ---
 ---Iterate over the lines in a file.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.lines)
 ---
 ---@param name string # The name (and path) of the file
 ---@return function iterator # A function that iterates over all the lines in the file
@@ -156,6 +213,9 @@ function love.filesystem.lines(name) end
 
 ---
 ---Loads a Lua file (but does not run it).
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.load)
 ---
 ---@param name string # The name (and path) of the file.
 ---@return function chunk # The loaded chunk.
@@ -166,6 +226,9 @@ function love.filesystem.load(name) end
 ---Mounts a zip file or folder in the game's save directory for reading.
 ---
 ---It is also possible to mount love.filesystem.getSourceBaseDirectory if the game is in fused mode.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.mount)
 ---
 ---@overload fun(filedata: love.FileData, mountpoint: string, appendToPath?: boolean):boolean
 ---@overload fun(data: love.Data, archivename: string, mountpoint: string, appendToPath?: boolean):boolean
@@ -180,6 +243,9 @@ function love.filesystem.mount(archive, mountpoint, appendToPath) end
 ---
 ---It needs to be opened before it can be accessed.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.newFile)
+---
 ---@overload fun(filename: string, mode: love.FileMode):love.File, string
 ---@param filename string # The filename of the file.
 ---@return love.File file # The new File object.
@@ -187,6 +253,9 @@ function love.filesystem.newFile(filename) end
 
 ---
 ---Creates a new FileData object from a file on disk, or from a string in memory.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.newFileData)
 ---
 ---@overload fun(originaldata: love.Data, name: string):love.FileData
 ---@overload fun(filepath: string):love.FileData, string
@@ -197,6 +266,9 @@ function love.filesystem.newFileData(contents, name) end
 
 ---
 ---Read the contents of a file.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.read)
 ---
 ---@overload fun(container: love.ContainerType, name: string, size?: number):love.FileData|string, number, nil, string
 ---@param name string # The name (and path) of the file.
@@ -210,6 +282,9 @@ function love.filesystem.read(name, size) end
 ---
 ---Removes a file or empty directory.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.remove)
+---
 ---@param name string # The file or directory to remove.
 ---@return boolean success # True if the file/directory was removed, false otherwise.
 function love.filesystem.remove(name) end
@@ -221,6 +296,9 @@ function love.filesystem.remove(name) end
 ---
 ---The paths are relative to the game's source and save directories, as well as any paths mounted with love.filesystem.mount.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.setCRequirePath)
+---
 ---@param paths string # The paths that the ''require'' function will check in love's filesystem.
 function love.filesystem.setCRequirePath(paths) end
 
@@ -228,6 +306,9 @@ function love.filesystem.setCRequirePath(paths) end
 ---Sets the write directory for your game. 
 ---
 ---Note that you can only set the name of the folder to store your files in, not the location.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.setIdentity)
 ---
 ---@overload fun(name: string)
 ---@param name string # The new identity that will be used as write directory.
@@ -240,11 +321,17 @@ function love.filesystem.setIdentity(name) end
 ---
 ---The paths are relative to the game's source and save directories, as well as any paths mounted with love.filesystem.mount.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.setRequirePath)
+---
 ---@param paths string # The paths that the ''require'' function will check in love's filesystem.
 function love.filesystem.setRequirePath(paths) end
 
 ---
 ---Sets the source of the game, where the code is present. This function can only be called once, and is normally automatically done by LÖVE.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.setSource)
 ---
 ---@param path string # Absolute path to the game's source folder.
 function love.filesystem.setSource(path) end
@@ -252,11 +339,17 @@ function love.filesystem.setSource(path) end
 ---
 ---Sets whether love.filesystem follows symbolic links. It is enabled by default in version 0.10.0 and newer, and disabled by default in 0.9.2.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.setSymlinksEnabled)
+---
 ---@param enable boolean # Whether love.filesystem should follow symbolic links.
 function love.filesystem.setSymlinksEnabled(enable) end
 
 ---
 ---Unmounts a zip file or folder previously mounted for reading with love.filesystem.mount.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.unmount)
 ---
 ---@param archive string # The folder or zip file in the game's save directory which is currently mounted.
 ---@return boolean success # True if the archive was successfully unmounted, false otherwise.
@@ -264,6 +357,9 @@ function love.filesystem.unmount(archive) end
 
 ---
 ---Write data to a file in the save directory. If the file existed already, it will be completely replaced by the new contents.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem.write)
 ---
 ---@overload fun(name: string, data: love.Data, size?: number):boolean, string
 ---@param name string # The name (and path) of the file.
@@ -278,11 +374,17 @@ function love.filesystem.write(name, data, size) end
 ---
 ---Note that the DroppedFile type can only be obtained from love.filedropped callback, and can't be constructed manually by the user.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem)
+---
 ---@class love.DroppedFile: love.File, love.Object
 local DroppedFile = {}
 
 ---
 ---Represents a file on the filesystem. A function that takes a file path can also take a File.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem)
 ---
 ---@class love.File: love.Object
 local File = {}
@@ -290,11 +392,17 @@ local File = {}
 ---
 ---Closes a File.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/File:close)
+---
 ---@return boolean success # Whether closing was successful.
 function File:close() end
 
 ---
 ---Flushes any buffered written data in the file to the disk.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/File:flush)
 ---
 ---@return boolean success # Whether the file successfully flushed any buffered data to the disk.
 ---@return string err # The error string, if an error occurred and the file could not be flushed.
@@ -303,6 +411,9 @@ function File:flush() end
 ---
 ---Gets the buffer mode of a file.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/File:getBuffer)
+---
 ---@return love.BufferMode mode # The current buffer mode of the file.
 ---@return number size # The maximum size in bytes of the file's buffer.
 function File:getBuffer() end
@@ -310,11 +421,17 @@ function File:getBuffer() end
 ---
 ---Gets the filename that the File object was created with. If the file object originated from the love.filedropped callback, the filename will be the full platform-dependent file path.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/File:getFilename)
+---
 ---@return string filename # The filename of the File.
 function File:getFilename() end
 
 ---
 ---Gets the FileMode the file has been opened with.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/File:getMode)
 ---
 ---@return love.FileMode mode # The mode this file has been opened with.
 function File:getMode() end
@@ -322,11 +439,17 @@ function File:getMode() end
 ---
 ---Returns the file size.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/File:getSize)
+---
 ---@return number size # The file size in bytes.
 function File:getSize() end
 
 ---
 ---Gets whether end-of-file has been reached.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/File:isEOF)
 ---
 ---@return boolean eof # Whether EOF has been reached.
 function File:isEOF() end
@@ -334,17 +457,26 @@ function File:isEOF() end
 ---
 ---Gets whether the file is open.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/File:isOpen)
+---
 ---@return boolean open # True if the file is currently open, false otherwise.
 function File:isOpen() end
 
 ---
 ---Iterate over all the lines in a file.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/File:lines)
+---
 ---@return function iterator # The iterator (can be used in for loops).
 function File:lines() end
 
 ---
 ---Open the file for write, read or append.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/File:open)
 ---
 ---@param mode love.FileMode # The mode to open the file in.
 ---@return boolean ok # True on success, false otherwise.
@@ -353,6 +485,9 @@ function File:open(mode) end
 
 ---
 ---Read a number of bytes from a file.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/File:read)
 ---
 ---@overload fun(self: love.File, container: love.ContainerType, bytes?: number):love.FileData|string, number
 ---@param bytes? number # The number of bytes to read.
@@ -363,6 +498,9 @@ function File:read(bytes) end
 ---
 ---Seek to a position in a file
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/File:seek)
+---
 ---@param pos number # The position to seek to
 ---@return boolean success # Whether the operation was successful
 function File:seek(pos) end
@@ -371,6 +509,9 @@ function File:seek(pos) end
 ---Sets the buffer mode for a file opened for writing or appending. Files with buffering enabled will not write data to the disk until the buffer size limit is reached, depending on the buffer mode.
 ---
 ---File:flush will force any buffered data to be written to the disk.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/File:setBuffer)
 ---
 ---@param mode love.BufferMode # The buffer mode to use.
 ---@param size? number # The maximum size in bytes of the file's buffer.
@@ -381,11 +522,17 @@ function File:setBuffer(mode, size) end
 ---
 ---Returns the position in the file.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/File:tell)
+---
 ---@return number pos # The current position.
 function File:tell() end
 
 ---
 ---Write data to a file.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/File:write)
 ---
 ---@overload fun(self: love.File, data: love.Data, size?: number):boolean, string
 ---@param data string # The string data to write.
@@ -397,11 +544,17 @@ function File:write(data, size) end
 ---
 ---Data representing the contents of a file.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.filesystem)
+---
 ---@class love.FileData: love.Data, love.Object
 local FileData = {}
 
 ---
 ---Gets the extension of the FileData.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/FileData:getExtension)
 ---
 ---@return string ext # The extension of the file the FileData represents.
 function FileData:getExtension() end
@@ -409,11 +562,17 @@ function FileData:getExtension() end
 ---
 ---Gets the filename of the FileData.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/FileData:getFilename)
+---
 ---@return string name # The name of the file the FileData represents.
 function FileData:getFilename() end
 
 ---
 ---Buffer modes for File objects.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/BufferMode)
 ---
 ---@alias love.BufferMode
 ---
@@ -432,6 +591,9 @@ function FileData:getFilename() end
 ---
 ---How to decode a given FileData.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/FileDecoder)
+---
 ---@alias love.FileDecoder
 ---
 ---The data is unencoded.
@@ -444,6 +606,9 @@ function FileData:getFilename() end
 
 ---
 ---The different modes you can open a File in.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/FileMode)
 ---
 ---@alias love.FileMode
 ---
@@ -465,6 +630,9 @@ function FileData:getFilename() end
 
 ---
 ---The type of a file.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/FileType)
 ---
 ---@alias love.FileType
 ---

--- a/meta/3rd/love2d/library/love/font.lua
+++ b/meta/3rd/love2d/library/love/font.lua
@@ -3,11 +3,17 @@
 ---
 ---Allows you to work with fonts.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.font)
+---
 ---@class love.font
 love.font = {}
 
 ---
 ---Creates a new BMFont Rasterizer.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.font.newBMFontRasterizer)
 ---
 ---@overload fun(fileName: string, glyphs: string, dpiscale?: number):love.Rasterizer
 ---@param imageData love.ImageData # The image data containing the drawable pictures of font glyphs.
@@ -19,12 +25,18 @@ function love.font.newBMFontRasterizer(imageData, glyphs, dpiscale) end
 ---
 ---Creates a new GlyphData.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.font.newGlyphData)
+---
 ---@param rasterizer love.Rasterizer # The Rasterizer containing the font.
 ---@param glyph number # The character code of the glyph.
 function love.font.newGlyphData(rasterizer, glyph) end
 
 ---
 ---Creates a new Image Rasterizer.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.font.newImageRasterizer)
 ---
 ---@param imageData love.ImageData # Font image data.
 ---@param glyphs string # String containing font glyphs.
@@ -35,6 +47,9 @@ function love.font.newImageRasterizer(imageData, glyphs, extraSpacing, dpiscale)
 
 ---
 ---Creates a new Rasterizer.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.font.newRasterizer)
 ---
 ---@overload fun(data: love.FileData):love.Rasterizer
 ---@overload fun(size?: number, hinting?: love.HintingMode, dpiscale?: number):love.Rasterizer
@@ -49,6 +64,9 @@ function love.font.newRasterizer(filename) end
 ---
 ---Creates a new TrueType Rasterizer.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.font.newTrueTypeRasterizer)
+---
 ---@overload fun(fileName: string, size?: number, hinting?: love.HintingMode, dpiscale?: number):love.Rasterizer
 ---@overload fun(fileData: love.FileData, size?: number, hinting?: love.HintingMode, dpiscale?: number):love.Rasterizer
 ---@param size? number # The font size.
@@ -60,11 +78,17 @@ function love.font.newTrueTypeRasterizer(size, hinting, dpiscale) end
 ---
 ---A GlyphData represents a drawable symbol of a font Rasterizer.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.font)
+---
 ---@class love.GlyphData: love.Data, love.Object
 local GlyphData = {}
 
 ---
 ---Gets glyph advance.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/GlyphData:getAdvance)
 ---
 ---@return number advance # Glyph advance.
 function GlyphData:getAdvance() end
@@ -72,12 +96,18 @@ function GlyphData:getAdvance() end
 ---
 ---Gets glyph bearing.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/GlyphData:getBearing)
+---
 ---@return number bx # Glyph bearing X.
 ---@return number by # Glyph bearing Y.
 function GlyphData:getBearing() end
 
 ---
 ---Gets glyph bounding box.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/GlyphData:getBoundingBox)
 ---
 ---@return number x # Glyph position x.
 ---@return number y # Glyph position y.
@@ -88,6 +118,9 @@ function GlyphData:getBoundingBox() end
 ---
 ---Gets glyph dimensions.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/GlyphData:getDimensions)
+---
 ---@return number width # Glyph width.
 ---@return number height # Glyph height.
 function GlyphData:getDimensions() end
@@ -95,11 +128,17 @@ function GlyphData:getDimensions() end
 ---
 ---Gets glyph pixel format.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/GlyphData:getFormat)
+---
 ---@return love.PixelFormat format # Glyph pixel format.
 function GlyphData:getFormat() end
 
 ---
 ---Gets glyph number.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/GlyphData:getGlyph)
 ---
 ---@return number glyph # Glyph number.
 function GlyphData:getGlyph() end
@@ -107,11 +146,17 @@ function GlyphData:getGlyph() end
 ---
 ---Gets glyph string.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/GlyphData:getGlyphString)
+---
 ---@return string glyph # Glyph string.
 function GlyphData:getGlyphString() end
 
 ---
 ---Gets glyph height.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/GlyphData:getHeight)
 ---
 ---@return number height # Glyph height.
 function GlyphData:getHeight() end
@@ -119,11 +164,17 @@ function GlyphData:getHeight() end
 ---
 ---Gets glyph width.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/GlyphData:getWidth)
+---
 ---@return number width # Glyph width.
 function GlyphData:getWidth() end
 
 ---
 ---A Rasterizer handles font rendering, containing the font data (image or TrueType font) and drawable glyphs.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.font)
 ---
 ---@class love.Rasterizer: love.Object
 local Rasterizer = {}
@@ -131,11 +182,17 @@ local Rasterizer = {}
 ---
 ---Gets font advance.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Rasterizer:getAdvance)
+---
 ---@return number advance # Font advance.
 function Rasterizer:getAdvance() end
 
 ---
 ---Gets ascent height.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Rasterizer:getAscent)
 ---
 ---@return number height # Ascent height.
 function Rasterizer:getAscent() end
@@ -143,17 +200,26 @@ function Rasterizer:getAscent() end
 ---
 ---Gets descent height.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Rasterizer:getDescent)
+---
 ---@return number height # Descent height.
 function Rasterizer:getDescent() end
 
 ---
 ---Gets number of glyphs in font.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Rasterizer:getGlyphCount)
+---
 ---@return number count # Glyphs count.
 function Rasterizer:getGlyphCount() end
 
 ---
 ---Gets glyph data of a specified glyph.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Rasterizer:getGlyphData)
 ---
 ---@overload fun(self: love.Rasterizer, glyphNumber: number):love.GlyphData
 ---@param glyph string # Glyph
@@ -163,17 +229,26 @@ function Rasterizer:getGlyphData(glyph) end
 ---
 ---Gets font height.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Rasterizer:getHeight)
+---
 ---@return number height # Font height
 function Rasterizer:getHeight() end
 
 ---
 ---Gets line height of a font.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Rasterizer:getLineHeight)
+---
 ---@return number height # Line height of a font.
 function Rasterizer:getLineHeight() end
 
 ---
 ---Checks if font contains specified glyphs.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Rasterizer:hasGlyphs)
 ---
 ---@param glyph1 string|number # Glyph
 ---@param glyph2 string|number # Glyph
@@ -183,6 +258,9 @@ function Rasterizer:hasGlyphs(glyph1, glyph2, ...) end
 
 ---
 ---True Type hinting mode.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/HintingMode)
 ---
 ---@alias love.HintingMode
 ---

--- a/meta/3rd/love2d/library/love/graphics.lua
+++ b/meta/3rd/love2d/library/love/graphics.lua
@@ -9,6 +9,9 @@
 ---
 ---Many of the functions are used to manipulate the graphics coordinate system, which is essentially the way coordinates are mapped to the display. You can change the position, scale, and even rotation in this way.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics)
+---
 ---@class love.graphics
 love.graphics = {}
 
@@ -17,11 +20,17 @@ love.graphics = {}
 ---
 ---This effectively multiplies the existing coordinate transformation's matrix with the Transform object's internal matrix to produce the new coordinate transformation.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.applyTransform)
+---
 ---@param transform love.Transform # The Transform object to apply to the current graphics coordinate transform.
 function love.graphics.applyTransform(transform) end
 
 ---
 ---Draws a filled or unfilled arc at position (x, y). The arc is drawn from angle1 to angle2 in radians. The segments parameter determines how many segments are used to draw the arc. The more segments, the smoother the edge.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.arc)
 ---
 ---@overload fun(drawmode: love.DrawMode, arctype: love.ArcType, x: number, y: number, radius: number, angle1: number, angle2: number, segments?: number)
 ---@param drawmode love.DrawMode # How to draw the arc.
@@ -38,6 +47,9 @@ function love.graphics.arc(drawmode, x, y, radius, angle1, angle2, segments) end
 ---
 ---Since this function enqueues a screenshot capture rather than executing it immediately, it can be called from an input callback or love.update and it will still capture all of what's drawn to the screen in that frame.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.captureScreenshot)
+---
 ---@overload fun(callback: function)
 ---@overload fun(channel: love.Channel)
 ---@param filename string # The filename to save the screenshot to. The encoded image type is determined based on the extension of the filename, and must be one of the ImageFormats.
@@ -45,6 +57,9 @@ function love.graphics.captureScreenshot(filename) end
 
 ---
 ---Draws a circle.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.circle)
 ---
 ---@overload fun(mode: love.DrawMode, x: number, y: number, radius: number, segments: number)
 ---@param mode love.DrawMode # How to draw the circle.
@@ -64,6 +79,9 @@ function love.graphics.circle(mode, x, y, radius) end
 ---
 ---In versions prior to background color instead.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.clear)
+---
 ---@overload fun(r: number, g: number, b: number, a?: number, clearstencil?: boolean, cleardepth?: boolean)
 ---@overload fun(color: table, ..., clearstencil?: boolean, cleardepth?: boolean)
 ---@overload fun(clearcolor: boolean, clearstencil: boolean, cleardepth: boolean)
@@ -75,6 +93,9 @@ function love.graphics.clear() end
 ---If the active Canvas has just been changed and the 'replace' BlendMode is about to be used to draw something which covers the entire screen, calling love.graphics.discard rather than calling love.graphics.clear or doing nothing may improve performance on mobile devices.
 ---
 ---On some desktop systems this function may do nothing.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.discard)
 ---
 ---@overload fun(discardcolors: table, discardstencil?: boolean)
 ---@param discardcolor? boolean # Whether to discard the texture(s) of the active Canvas(es) (the contents of the screen if no Canvas is active.)
@@ -95,6 +116,9 @@ function love.graphics.discard(discardcolor, discardstencil) end
 ---When using the default shader anything drawn with this function will be tinted according to the currently selected color.
 ---
 ---Set it to pure white to preserve the object's original colors.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.draw)
 ---
 ---@overload fun(texture: love.Texture, quad: love.Quad, x: number, y: number, r?: number, sx?: number, sy?: number, ox?: number, oy?: number, kx?: number, ky?: number)
 ---@overload fun(drawable: love.Drawable, transform: love.Transform)
@@ -118,6 +142,9 @@ function love.graphics.draw(drawable, x, y, r, sx, sy, ox, oy, kx, ky) end
 ---
 ---Instancing is not supported by some older GPUs that are only capable of using OpenGL ES 2 or OpenGL 2. Use love.graphics.getSupported to check.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.drawInstanced)
+---
 ---@overload fun(mesh: love.Mesh, instancecount: number, transform: love.Transform)
 ---@param mesh love.Mesh # The mesh to render.
 ---@param instancecount number # The number of instances to render.
@@ -134,6 +161,9 @@ function love.graphics.drawInstanced(mesh, instancecount, x, y, r, sx, sy, ox, o
 
 ---
 ---Draws a layer of an Array Texture.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.drawLayer)
 ---
 ---@overload fun(texture: love.Texture, layerindex: number, quad: love.Quad, x?: number, y?: number, r?: number, sx?: number, sy?: number, ox?: number, oy?: number, kx?: number, ky?: number)
 ---@overload fun(texture: love.Texture, layerindex: number, transform: love.Transform)
@@ -154,6 +184,9 @@ function love.graphics.drawLayer(texture, layerindex, x, y, r, sx, sy, ox, oy, k
 ---
 ---Draws an ellipse.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.ellipse)
+---
 ---@overload fun(mode: love.DrawMode, x: number, y: number, radiusx: number, radiusy: number, segments: number)
 ---@param mode love.DrawMode # How to draw the ellipse.
 ---@param x number # The position of the center along x-axis.
@@ -171,12 +204,18 @@ function love.graphics.ellipse(mode, x, y, radiusx, radiusy) end
 ---
 ---SpriteBatches, ParticleSystems, Meshes, and Text objects do their own batching and do not affect automatic batching of other draws, aside from flushing the current batch when they're drawn.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.flushBatch)
+---
 function love.graphics.flushBatch() end
 
 ---
 ---Gets the current background color.
 ---
 ---In versions prior to 11.0, color component values were within the range of 0 to 255 instead of 0 to 1.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getBackgroundColor)
 ---
 ---@return number r # The red component (0-1).
 ---@return number g # The green component (0-1).
@@ -187,6 +226,9 @@ function love.graphics.getBackgroundColor() end
 ---
 ---Gets the blending mode.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getBlendMode)
+---
 ---@return love.BlendMode mode # The current blend mode.
 ---@return love.BlendAlphaMode alphamode # The current blend alpha mode – it determines how the alpha of drawn objects affects blending.
 function love.graphics.getBlendMode() end
@@ -194,11 +236,17 @@ function love.graphics.getBlendMode() end
 ---
 ---Gets the current target Canvas.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getCanvas)
+---
 ---@return love.Canvas canvas # The Canvas set by setCanvas. Returns nil if drawing to the real screen.
 function love.graphics.getCanvas() end
 
 ---
 ---Gets the available Canvas formats, and whether each is supported.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getCanvasFormats)
 ---
 ---@overload fun(readable: boolean):table
 ---@return table formats # A table containing CanvasFormats as keys, and a boolean indicating whether the format is supported as values. Not all systems support all formats.
@@ -208,6 +256,9 @@ function love.graphics.getCanvasFormats() end
 ---Gets the current color.
 ---
 ---In versions prior to 11.0, color component values were within the range of 0 to 255 instead of 0 to 1.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getColor)
 ---
 ---@return number r # The red component (0-1).
 ---@return number g # The green component (0-1).
@@ -219,6 +270,9 @@ function love.graphics.getColor() end
 ---Gets the active color components used when drawing. Normally all 4 components are active unless love.graphics.setColorMask has been used.
 ---
 ---The color mask determines whether individual components of the colors of drawn objects will affect the color of the screen. They affect love.graphics.clear and Canvas:clear as well.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getColorMask)
 ---
 ---@return boolean r # Whether the red color component is active when rendering.
 ---@return boolean g # Whether the green color component is active when rendering.
@@ -235,11 +289,17 @@ function love.graphics.getColorMask() end
 ---
 ---The highdpi window flag must be enabled to use the full pixel density of a Retina screen on Mac OS X and iOS. The flag currently does nothing on Windows and Linux, and on Android it is effectively always enabled.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getDPIScale)
+---
 ---@return number scale # The pixel scale factor associated with the window.
 function love.graphics.getDPIScale() end
 
 ---
 ---Returns the default scaling filters used with Images, Canvases, and Fonts.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getDefaultFilter)
 ---
 ---@return love.FilterMode min # Filter mode used when scaling the image down.
 ---@return love.FilterMode mag # Filter mode used when scaling the image up.
@@ -251,6 +311,9 @@ function love.graphics.getDefaultFilter() end
 ---
 ---This is low-level functionality designed for use with custom vertex shaders and Meshes with custom vertex attributes. No higher level APIs are provided to set the depth of 2D graphics such as shapes, lines, and Images.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getDepthMode)
+---
 ---@return love.CompareMode comparemode # Depth comparison mode used for depth testing.
 ---@return boolean write # Whether to write update / write values to the depth buffer when rendering.
 function love.graphics.getDepthMode() end
@@ -258,12 +321,18 @@ function love.graphics.getDepthMode() end
 ---
 ---Gets the width and height in pixels of the window.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getDimensions)
+---
 ---@return number width # The width of the window.
 ---@return number height # The height of the window.
 function love.graphics.getDimensions() end
 
 ---
 ---Gets the current Font object.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getFont)
 ---
 ---@return love.Font font # The current Font. Automatically creates and sets the default font, if none is set yet.
 function love.graphics.getFont() end
@@ -273,11 +342,17 @@ function love.graphics.getFont() end
 ---
 ---This is designed for use in combination with Mesh face culling. Other love.graphics shapes, lines, and sprites are not guaranteed to have a specific winding order to their internal vertices.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getFrontFaceWinding)
+---
 ---@return love.VertexWinding winding # The winding mode being used. The default winding is counterclockwise ('ccw').
 function love.graphics.getFrontFaceWinding() end
 
 ---
 ---Gets the height in pixels of the window.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getHeight)
 ---
 ---@return number height # The height of the window.
 function love.graphics.getHeight() end
@@ -285,11 +360,17 @@ function love.graphics.getHeight() end
 ---
 ---Gets the raw and compressed pixel formats usable for Images, and whether each is supported.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getImageFormats)
+---
 ---@return table formats # A table containing PixelFormats as keys, and a boolean indicating whether the format is supported as values. Not all systems support all formats.
 function love.graphics.getImageFormats() end
 
 ---
 ---Gets the line join style.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getLineJoin)
 ---
 ---@return love.LineJoin join # The LineJoin style.
 function love.graphics.getLineJoin() end
@@ -297,11 +378,17 @@ function love.graphics.getLineJoin() end
 ---
 ---Gets the line style.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getLineStyle)
+---
 ---@return love.LineStyle style # The current line style.
 function love.graphics.getLineStyle() end
 
 ---
 ---Gets the current line width.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getLineWidth)
 ---
 ---@return number width # The current line width.
 function love.graphics.getLineWidth() end
@@ -311,6 +398,9 @@ function love.graphics.getLineWidth() end
 ---
 ---Mesh face culling is designed for use with low level custom hardware-accelerated 3D rendering via custom vertex attributes on Meshes, custom vertex shaders, and depth testing with a depth buffer.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getMeshCullMode)
+---
 ---@return love.CullMode mode # The Mesh face culling mode in use (whether to render everything, cull back-facing triangles, or cull front-facing triangles).
 function love.graphics.getMeshCullMode() end
 
@@ -318,6 +408,9 @@ function love.graphics.getMeshCullMode() end
 ---Gets the width and height in pixels of the window.
 ---
 ---love.graphics.getDimensions gets the dimensions of the window in units scaled by the screen's DPI scale factor, rather than pixels. Use getDimensions for calculations related to drawing to the screen and using the graphics coordinate system (calculating the center of the screen, for example), and getPixelDimensions only when dealing specifically with underlying pixels (pixel-related calculations in a pixel Shader, for example).
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getPixelDimenions)
 ---
 ---@return number pixelwidth # The width of the window in pixels.
 ---@return number pixelheight # The height of the window in pixels.
@@ -328,6 +421,9 @@ function love.graphics.getPixelDimenions() end
 ---
 ---The graphics coordinate system and DPI scale factor, rather than raw pixels. Use getHeight for calculations related to drawing to the screen and using the coordinate system (calculating the center of the screen, for example), and getPixelHeight only when dealing specifically with underlying pixels (pixel-related calculations in a pixel Shader, for example).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getPixelHeight)
+---
 ---@return number pixelheight # The height of the window in pixels.
 function love.graphics.getPixelHeight() end
 
@@ -336,17 +432,26 @@ function love.graphics.getPixelHeight() end
 ---
 ---The graphics coordinate system and DPI scale factor, rather than raw pixels. Use getWidth for calculations related to drawing to the screen and using the coordinate system (calculating the center of the screen, for example), and getPixelWidth only when dealing specifically with underlying pixels (pixel-related calculations in a pixel Shader, for example).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getPixelWidth)
+---
 ---@return number pixelwidth # The width of the window in pixels.
 function love.graphics.getPixelWidth() end
 
 ---
 ---Gets the point size.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getPointSize)
+---
 ---@return number size # The current point size.
 function love.graphics.getPointSize() end
 
 ---
 ---Gets information about the system's video card and drivers.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getRendererInfo)
 ---
 ---@return string name # The name of the renderer, e.g. 'OpenGL' or 'OpenGL ES'.
 ---@return string version # The version of the renderer with some extra driver-dependent version info, e.g. '2.1 INTEL-8.10.44'.
@@ -357,6 +462,9 @@ function love.graphics.getRendererInfo() end
 ---
 ---Gets the current scissor box.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getScissor)
+---
 ---@return number x # The x-component of the top-left point of the box.
 ---@return number y # The y-component of the top-left point of the box.
 ---@return number width # The width of the box.
@@ -366,17 +474,26 @@ function love.graphics.getScissor() end
 ---
 ---Gets the current Shader. Returns nil if none is set.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getShader)
+---
 ---@return love.Shader shader # The currently active Shader, or nil if none is set.
 function love.graphics.getShader() end
 
 ---
 ---Gets the current depth of the transform / state stack (the number of pushes without corresponding pops).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getStackDepth)
+---
 ---@return number depth # The current depth of the transform and state love.graphics stack.
 function love.graphics.getStackDepth() end
 
 ---
 ---Gets performance-related rendering statistics. 
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getStats)
 ---
 ---@overload fun(stats: table):table
 ---@return {drawcalls: number, canvasswitches: number, texturememory: number, images: number, canvases: number, fonts: number, shaderswitches: number, drawcallsbatched: number} stats # A table with the following fields:
@@ -389,6 +506,9 @@ function love.graphics.getStats() end
 ---
 ---Each Canvas has its own per-pixel stencil values.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getStencilTest)
+---
 ---@return love.CompareMode comparemode # The type of comparison that is made for each pixel. Will be 'always' if stencil testing is disabled.
 ---@return number comparevalue # The value used when comparing with the stencil value of each pixel.
 function love.graphics.getStencilTest() end
@@ -398,11 +518,17 @@ function love.graphics.getStencilTest() end
 ---
 ---Some older or low-end systems don't always support all graphics features.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getSupported)
+---
 ---@return table features # A table containing GraphicsFeature keys, and boolean values indicating whether each feature is supported.
 function love.graphics.getSupported() end
 
 ---
 ---Gets the system-dependent maximum values for love.graphics features.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getSystemLimits)
 ---
 ---@return table limits # A table containing GraphicsLimit keys, and number values.
 function love.graphics.getSystemLimits() end
@@ -410,11 +536,17 @@ function love.graphics.getSystemLimits() end
 ---
 ---Gets the available texture types, and whether each is supported.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getTextureTypes)
+---
 ---@return table texturetypes # A table containing TextureTypes as keys, and a boolean indicating whether the type is supported as values. Not all systems support all types.
 function love.graphics.getTextureTypes() end
 
 ---
 ---Gets the width in pixels of the window.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.getWidth)
 ---
 ---@return number width # The width of the window.
 function love.graphics.getWidth() end
@@ -428,6 +560,9 @@ function love.graphics.getWidth() end
 ---
 ---The dimensions of the scissor is unaffected by graphical transformations (translate, scale, ...).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.intersectScissor)
+---
 ---@param x number # The x-coordinate of the upper left corner of the rectangle to intersect with the existing scissor rectangle.
 ---@param y number # The y-coordinate of the upper left corner of the rectangle to intersect with the existing scissor rectangle.
 ---@param width number # The width of the rectangle to intersect with the existing scissor rectangle.
@@ -439,6 +574,9 @@ function love.graphics.intersectScissor(x, y, width, height) end
 ---
 ---This effectively applies the reverse of the current graphics transformations to the given position. A similar Transform:inverseTransformPoint method exists for Transform objects.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.inverseTransformPoint)
+---
 ---@param screenX number # The x component of the screen-space position.
 ---@param screenY number # The y component of the screen-space position.
 ---@return number globalX # The x component of the position in global coordinates.
@@ -449,6 +587,9 @@ function love.graphics.inverseTransformPoint(screenX, screenY) end
 ---Gets whether the graphics module is able to be used. If it is not active, love.graphics function and method calls will not work correctly and may cause the program to crash.
 ---The graphics module is inactive if a window is not open, or if the app is in the background on iOS. Typically the app's execution will be automatically paused by the system, in the latter case.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.isActive)
+---
 ---@return boolean active # Whether the graphics module is active and able to be used.
 function love.graphics.isActive() end
 
@@ -457,17 +598,26 @@ function love.graphics.isActive() end
 ---
 ---Not all devices support gamma-correct rendering, in which case it will be automatically disabled and this function will return false. It is supported on desktop systems which have graphics cards that are capable of using OpenGL 3 / DirectX 10, and iOS devices that can use OpenGL ES 3.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.isGammaCorrect)
+---
 ---@return boolean gammacorrect # True if gamma-correct rendering is supported and was enabled in love.conf, false otherwise.
 function love.graphics.isGammaCorrect() end
 
 ---
 ---Gets whether wireframe mode is used when drawing.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.isWireframe)
+---
 ---@return boolean wireframe # True if wireframe lines are used when drawing, false if it's not.
 function love.graphics.isWireframe() end
 
 ---
 ---Draws lines between points.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.line)
 ---
 ---@overload fun(points: table)
 ---@param x1 number # The position of first point on the x-axis.
@@ -486,6 +636,9 @@ function love.graphics.line(x1, y1, x2, y2, ...) end
 ---
 ---To use an array image in a Shader, it must be declared as a ArrayImage or sampler2DArray type (instead of Image or sampler2D). The Texel(ArrayImage image, vec3 texturecoord) shader function must be used to get pixel colors from a slice of the array image. The vec3 argument contains the texture coordinate in the first two components, and the 0-based slice index in the third component.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.newArrayImage)
+---
 ---@param slices table # A table containing filepaths to images (or File, FileData, ImageData, or CompressedImageData objects), in an array. Each sub-image must have the same dimensions. A table of tables can also be given, where each sub-table contains all mipmap levels for the slice index of that sub-table.
 ---@param settings? {mipmaps: boolean, linear: boolean, dpiscale: number} # Optional table of settings to configure the array image, containing the following fields:
 ---@return love.Image image # An Array Image object.
@@ -493,6 +646,9 @@ function love.graphics.newArrayImage(slices, settings) end
 
 ---
 ---Creates a new Canvas object for offscreen rendering.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.newCanvas)
 ---
 ---@overload fun(width: number, height: number):love.Canvas
 ---@overload fun(width: number, height: number, settings: table):love.Canvas
@@ -545,6 +701,9 @@ function love.graphics.newCanvas() end
 ---
 ---+x -x +y -y +z -z
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.newCubeImage)
+---
 ---@overload fun(faces: table, settings?: table):love.Image
 ---@param filename string # The filepath to a cubemap image file (or a File, FileData, or ImageData).
 ---@param settings? {mipmaps: boolean, linear: boolean} # Optional table of settings to configure the cubemap image, containing the following fields:
@@ -556,6 +715,9 @@ function love.graphics.newCubeImage(filename, settings) end
 ---
 ---All variants which accept a filename can also accept a Data object instead.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.newFont)
+---
 ---@overload fun(filename: string, size: number, hinting?: love.HintingMode, dpiscale?: number):love.Font
 ---@overload fun(filename: string, imagefilename: string):love.Font
 ---@overload fun(size?: number, hinting?: love.HintingMode, dpiscale?: number):love.Font
@@ -566,18 +728,24 @@ function love.graphics.newFont(filename) end
 ---
 ---Creates a new Image from a filepath, FileData, an ImageData, or a CompressedImageData, and optionally generates or specifies mipmaps for the image.
 ---
----@overload fun(fileData: love.FileData, settings?: table):love.Image
----@overload fun(imageData: love.ImageData, settings?: table):love.Image
----@overload fun(compressedImageData: love.CompressedImageData, settings?: table):love.Image
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.newImage)
+---
+---@overload fun(fileData: love.FileData, flags?: table):love.Image
+---@overload fun(imageData: love.ImageData, flags?: table):love.Image
+---@overload fun(compressedImageData: love.CompressedImageData, flags?: table):love.Image
 ---@param filename string # The filepath to the image file.
----@param settings? {dpiscale: number, linear: boolean, mipmaps: boolean} # A table containing the following fields:
+---@param flags? {dpiscale: number, linear: boolean, mipmaps: boolean} # A table containing the following fields:
 ---@return love.Image image # A new Image object which can be drawn on screen.
-function love.graphics.newImage(filename, settings) end
+function love.graphics.newImage(filename, flags) end
 
 ---
 ---Creates a new specifically formatted image.
 ---
 ---In versions prior to 0.9.0, LÖVE expects ISO 8859-1 encoding for the glyphs string.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.newImageFont)
 ---
 ---@overload fun(imageData: love.ImageData, glyphs: string):love.Font
 ---@overload fun(filename: string, glyphs: string, extraspacing: number):love.Font
@@ -593,6 +761,9 @@ function love.graphics.newImageFont(filename, glyphs) end
 ---
 ---In versions prior to 11.0, color and byte component values were within the range of 0 to 255 instead of 0 to 1.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.newMesh)
+---
 ---@overload fun(vertexcount: number, mode?: love.MeshDrawMode, usage?: love.SpriteBatchUsage):love.Mesh
 ---@overload fun(vertexformat: table, vertices: table, mode?: love.MeshDrawMode, usage?: love.SpriteBatchUsage):love.Mesh
 ---@overload fun(vertexformat: table, vertexcount: number, mode?: love.MeshDrawMode, usage?: love.SpriteBatchUsage):love.Mesh
@@ -606,6 +777,9 @@ function love.graphics.newMesh(vertices, mode, usage) end
 ---
 ---Creates a new ParticleSystem.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.newParticleSystem)
+---
 ---@overload fun(texture: love.Texture, buffer?: number):love.ParticleSystem
 ---@param image love.Image # The image to use.
 ---@param buffer? number # The max number of particles at the same time.
@@ -616,6 +790,9 @@ function love.graphics.newParticleSystem(image, buffer) end
 ---Creates a new Quad.
 ---
 ---The purpose of a Quad is to use a fraction of an image to draw objects, as opposed to drawing entire image. It is most useful for sprite sheets and atlases: in a sprite atlas, multiple sprites reside in same image, quad is used to draw a specific sprite from that image; in animated sprites with all frames residing in the same image, quad is used to draw specific frame from the animation.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.newQuad)
 ---
 ---@param x number # The top-left position in the Image along the x-axis.
 ---@param y number # The top-left position in the Image along the y-axis.
@@ -631,6 +808,9 @@ function love.graphics.newQuad(x, y, width, height, sw, sh) end
 ---
 ---Shaders are small programs which are run on the graphics card when drawing. Vertex shaders are run once for each vertex (for example, an image has 4 vertices - one at each corner. A Mesh might have many more.) Pixel shaders are run once for each pixel on the screen which the drawn object touches. Pixel shader code is executed after all the object's vertices have been processed by the vertex shader.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.newShader)
+---
 ---@overload fun(pixelcode: string, vertexcode: string):love.Shader
 ---@param code string # The pixel shader or vertex shader code, or a filename pointing to a file with the code.
 ---@return love.Shader shader # A Shader object for use in drawing operations.
@@ -638,6 +818,9 @@ function love.graphics.newShader(code) end
 
 ---
 ---Creates a new SpriteBatch object.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.newSpriteBatch)
 ---
 ---@overload fun(image: love.Image, maxsprites?: number, usage?: love.SpriteBatchUsage):love.SpriteBatch
 ---@overload fun(texture: love.Texture, maxsprites?: number, usage?: love.SpriteBatchUsage):love.SpriteBatch
@@ -649,6 +832,9 @@ function love.graphics.newSpriteBatch(image, maxsprites) end
 ---
 ---Creates a new drawable Text object.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.newText)
+---
 ---@param font love.Font # The font to use for the text.
 ---@param textstring? string # The initial string of text that the new Text object will contain. May be nil.
 ---@return love.Text text # The new drawable Text object.
@@ -656,6 +842,9 @@ function love.graphics.newText(font, textstring) end
 
 ---
 ---Creates a new drawable Video. Currently only Ogg Theora video files are supported.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.newVideo)
 ---
 ---@overload fun(videostream: love.VideoStream):love.Video
 ---@overload fun(filename: string, settings?: table):love.Video
@@ -676,6 +865,9 @@ function love.graphics.newVideo(filename) end
 ---
 ---Array images are a much better choice than volume images for storing multiple different sprites in a single array image for directly drawing them.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.newVolumeImage)
+---
 ---@param layers table # A table containing filepaths to images (or File, FileData, ImageData, or CompressedImageData objects), in an array. A table of tables can also be given, where each sub-table represents a single mipmap level and contains all layers for that mipmap.
 ---@param settings? {mipmaps: boolean, linear: boolean} # Optional table of settings to configure the volume image, containing the following fields:
 ---@return love.Image image # A volume Image object.
@@ -686,10 +878,16 @@ function love.graphics.newVolumeImage(layers, settings) end
 ---
 ---This function is always used to reverse any previous calls to love.graphics.rotate, love.graphics.scale, love.graphics.shear or love.graphics.translate. It returns the current transformation state to its defaults.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.origin)
+---
 function love.graphics.origin() end
 
 ---
 ---Draws one or more points.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.points)
 ---
 ---@overload fun(points: table)
 ---@overload fun(points: table)
@@ -703,6 +901,9 @@ function love.graphics.points(x, y, ...) end
 ---
 ---Following the mode argument, this function can accept multiple numeric arguments or a single table of numeric arguments. In either case the arguments are interpreted as alternating x and y coordinates of the polygon's vertices.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.polygon)
+---
 ---@overload fun(mode: love.DrawMode, vertices: table)
 ---@param mode love.DrawMode # How to draw the polygon.
 ---@vararg number # The vertices of the polygon.
@@ -713,12 +914,18 @@ function love.graphics.polygon(mode, ...) end
 ---
 ---This function is always used to reverse a previous push operation. It returns the current transformation state to what it was before the last preceding push.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.pop)
+---
 function love.graphics.pop() end
 
 ---
 ---Displays the results of drawing operations on the screen.
 ---
 ---This function is used when writing your own love.run function. It presents all the results of your drawing operations on the screen. See the example in love.run for a typical use of this function.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.present)
 ---
 function love.graphics.present() end
 
@@ -732,6 +939,9 @@ function love.graphics.present() end
 ---love.graphics.print and love.graphics.printf both support UTF-8 encoding. You'll also need a proper Font for special characters.
 ---
 ---In versions prior to 11.0, color and byte component values were within the range of 0 to 255 instead of 0 to 1.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.print)
 ---
 ---@overload fun(coloredtext: table, x?: number, y?: number, angle?: number, sx?: number, sy?: number, ox?: number, oy?: number, kx?: number, ky?: number)
 ---@overload fun(text: string, transform: love.Transform)
@@ -761,6 +971,9 @@ function love.graphics.print(text, x, y, r, sx, sy, ox, oy, kx, ky) end
 ---
 ---In versions prior to 11.0, color and byte component values were within the range of 0 to 255 instead of 0 to 1.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.printf)
+---
 ---@overload fun(text: string, font: love.Font, x: number, y: number, limit: number, align?: love.AlignMode, r?: number, sx?: number, sy?: number, ox?: number, oy?: number, kx?: number, ky?: number)
 ---@overload fun(text: string, transform: love.Transform, limit: number, align?: love.AlignMode)
 ---@overload fun(text: string, font: love.Font, transform: love.Transform, limit: number, align?: love.AlignMode)
@@ -787,11 +1000,17 @@ function love.graphics.printf(text, x, y, limit, align, r, sx, sy, ox, oy, kx, k
 ---
 ---This function is always used to prepare for a corresponding pop operation later. It stores the current coordinate transformation state into the transformation stack and keeps it active. Later changes to the transformation can be undone by using the pop operation, which returns the coordinate transform to the state it was in before calling push.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.push)
+---
 ---@overload fun(stack: love.StackType)
 function love.graphics.push() end
 
 ---
 ---Draws a rectangle.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.rectangle)
 ---
 ---@overload fun(mode: love.DrawMode, x: number, y: number, width: number, height: number, rx: number, ry?: number, segments?: number)
 ---@param mode love.DrawMode # How to draw the rectangle.
@@ -804,6 +1023,9 @@ function love.graphics.rectangle(mode, x, y, width, height) end
 ---
 ---Replaces the current coordinate transformation with the given Transform object.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.replaceTransform)
+---
 ---@param transform love.Transform # The Transform object to replace the current graphics coordinate transform with.
 function love.graphics.replaceTransform(transform) end
 
@@ -812,12 +1034,18 @@ function love.graphics.replaceTransform(transform) end
 ---
 ---Calling reset makes the current drawing color white, the current background color black, disables any active color component masks, disables wireframe mode and resets the current graphics transformation to the origin. It also sets both the point and line drawing modes to smooth and their sizes to 1.0.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.reset)
+---
 function love.graphics.reset() end
 
 ---
 ---Rotates the coordinate system in two dimensions.
 ---
 ---Calling this function affects all future drawing operations by rotating the coordinate system around the origin by the given amount of radians. This change lasts until love.draw() exits.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.rotate)
 ---
 ---@param angle number # The amount to rotate the coordinate system in radians.
 function love.graphics.rotate(angle) end
@@ -833,6 +1061,9 @@ function love.graphics.rotate(angle) end
 ---
 ---Scaling lasts until love.draw() exits.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.scale)
+---
 ---@param sx number # The scaling in the direction of the x-axis.
 ---@param sy? number # The scaling in the direction of the y-axis. If omitted, it defaults to same as parameter sx.
 function love.graphics.scale(sx, sy) end
@@ -840,7 +1071,11 @@ function love.graphics.scale(sx, sy) end
 ---
 ---Sets the background color.
 ---
----@overload fun(rgba: table)
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setBackgroundColor)
+---
+---@overload fun()
+---@overload fun()
 ---@param red number # The red component (0-1).
 ---@param green number # The green component (0-1).
 ---@param blue number # The blue component (0-1).
@@ -850,12 +1085,18 @@ function love.graphics.setBackgroundColor(red, green, blue, alpha) end
 ---
 ---Sets the blending mode.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setBlendMode)
+---
 ---@overload fun(mode: love.BlendMode, alphamode?: love.BlendAlphaMode)
 ---@param mode love.BlendMode # The blend mode to use.
 function love.graphics.setBlendMode(mode) end
 
 ---
 ---Captures drawing operations to a Canvas.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setCanvas)
 ---
 ---@overload fun()
 ---@overload fun(canvas1: love.Canvas, canvas2: love.Canvas, ...)
@@ -870,6 +1111,9 @@ function love.graphics.setCanvas(canvas, mipmap) end
 ---
 ---In versions prior to 11.0, color component values were within the range of 0 to 255 instead of 0 to 1.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setColor)
+---
 ---@overload fun(rgba: table)
 ---@param red number # The amount of red.
 ---@param green number # The amount of green.
@@ -879,6 +1123,9 @@ function love.graphics.setColor(red, green, blue, alpha) end
 
 ---
 ---Sets the color mask. Enables or disables specific color components when rendering and clearing the screen. For example, if '''red''' is set to '''false''', no further changes will be made to the red component of any pixels.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setColorMask)
 ---
 ---@overload fun()
 ---@param red boolean # Render red component.
@@ -890,6 +1137,9 @@ function love.graphics.setColorMask(red, green, blue, alpha) end
 ---
 ---Sets the default scaling filters used with Images, Canvases, and Fonts.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setDefaultFilter)
+---
 ---@param min love.FilterMode # Filter mode used when scaling the image down.
 ---@param mag love.FilterMode # Filter mode used when scaling the image up.
 ---@param anisotropy? number # Maximum amount of Anisotropic Filtering used.
@@ -899,6 +1149,9 @@ function love.graphics.setDefaultFilter(min, mag, anisotropy) end
 ---Configures depth testing and writing to the depth buffer.
 ---
 ---This is low-level functionality designed for use with custom vertex shaders and Meshes with custom vertex attributes. No higher level APIs are provided to set the depth of 2D graphics such as shapes, lines, and Images.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setDepthMode)
 ---
 ---@overload fun()
 ---@param comparemode love.CompareMode # Depth comparison mode used for depth testing.
@@ -910,6 +1163,9 @@ function love.graphics.setDepthMode(comparemode, write) end
 ---
 ---It's recommended that Font objects are created with love.graphics.newFont in the loading stage and then passed to this function in the drawing stage.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setFont)
+---
 ---@param font love.Font # The Font object to use.
 function love.graphics.setFont(font) end
 
@@ -918,11 +1174,17 @@ function love.graphics.setFont(font) end
 ---
 ---This is designed for use in combination with Mesh face culling. Other love.graphics shapes, lines, and sprites are not guaranteed to have a specific winding order to their internal vertices.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setFrontFaceWinding)
+---
 ---@param winding love.VertexWinding # The winding mode to use. The default winding is counterclockwise ('ccw').
 function love.graphics.setFrontFaceWinding(winding) end
 
 ---
 ---Sets the line join style. See LineJoin for the possible options.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setLineJoin)
 ---
 ---@param join love.LineJoin # The LineJoin to use.
 function love.graphics.setLineJoin(join) end
@@ -930,11 +1192,17 @@ function love.graphics.setLineJoin(join) end
 ---
 ---Sets the line style.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setLineStyle)
+---
 ---@param style love.LineStyle # The LineStyle to use. Line styles include smooth and rough.
 function love.graphics.setLineStyle(style) end
 
 ---
 ---Sets the line width.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setLineWidth)
 ---
 ---@param width number # The width of the line.
 function love.graphics.setLineWidth(width) end
@@ -946,11 +1214,17 @@ function love.graphics.setLineWidth(width) end
 ---
 ---By default, both front- and back-facing triangles in Meshes are rendered.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setMeshCullMode)
+---
 ---@param mode love.CullMode # The Mesh face culling mode to use (whether to render everything, cull back-facing triangles, or cull front-facing triangles).
 function love.graphics.setMeshCullMode(mode) end
 
 ---
 ---Creates and sets a new Font.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setNewFont)
 ---
 ---@overload fun(filename: string, size?: number):love.Font
 ---@overload fun(file: love.File, size?: number):love.Font
@@ -963,6 +1237,9 @@ function love.graphics.setNewFont(size) end
 ---
 ---Sets the point size.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setPointSize)
+---
 ---@param size number # The new point size.
 function love.graphics.setPointSize(size) end
 
@@ -972,6 +1249,9 @@ function love.graphics.setPointSize(size) end
 ---The scissor limits the drawing area to a specified rectangle. This affects all graphics calls, including love.graphics.clear. 
 ---
 ---The dimensions of the scissor is unaffected by graphical transformations (translate, scale, ...).
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setScissor)
 ---
 ---@overload fun()
 ---@param x number # x coordinate of upper left corner.
@@ -983,6 +1263,9 @@ function love.graphics.setScissor(x, y, width, height) end
 ---
 ---Sets or resets a Shader as the current pixel effect or vertex shaders. All drawing operations until the next ''love.graphics.setShader'' will be drawn using the Shader object specified.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setShader)
+---
 ---@overload fun()
 ---@param shader love.Shader # The new shader.
 function love.graphics.setShader(shader) end
@@ -992,6 +1275,9 @@ function love.graphics.setShader(shader) end
 ---
 ---When stencil testing is enabled, the geometry of everything that is drawn afterward will be clipped / stencilled out based on a comparison between the arguments of this function and the stencil value of each pixel that the geometry touches. The stencil values of pixels are affected via love.graphics.stencil.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setStencilTest)
+---
 ---@overload fun()
 ---@param comparemode love.CompareMode # The type of comparison to make for each pixel.
 ---@param comparevalue number # The value to use when comparing with the stencil value of each pixel. Must be between 0 and 255.
@@ -1000,11 +1286,17 @@ function love.graphics.setStencilTest(comparemode, comparevalue) end
 ---
 ---Sets whether wireframe lines will be used when drawing.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.setWireframe)
+---
 ---@param enable boolean # True to enable wireframe mode when drawing, false to disable it.
 function love.graphics.setWireframe(enable) end
 
 ---
 ---Shears the coordinate system.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.shear)
 ---
 ---@param kx number # The shear factor on the x-axis.
 ---@param ky number # The shear factor on the y-axis.
@@ -1017,6 +1309,9 @@ function love.graphics.shear(kx, ky) end
 ---
 ---Stencil values are integers within the range of 255.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.stencil)
+---
 ---@param stencilfunction function # Function which draws geometry. The stencil values of pixels, rather than the color of each pixel, will be affected by the geometry.
 ---@param action? love.StencilAction # How to modify any stencil values of pixels that are touched by what's drawn in the stencil function.
 ---@param value? number # The new stencil value to use for pixels if the 'replace' stencil action is used. Has no effect with other stencil actions. Must be between 0 and 255.
@@ -1027,6 +1322,9 @@ function love.graphics.stencil(stencilfunction, action, value, keepvalues) end
 ---Converts the given 2D position from global coordinates into screen-space.
 ---
 ---This effectively applies the current graphics transformations to the given position. A similar Transform:transformPoint method exists for Transform objects.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.transformPoint)
 ---
 ---@param globalX number # The x component of the position in global coordinates.
 ---@param globalY number # The y component of the position in global coordinates.
@@ -1045,12 +1343,18 @@ function love.graphics.transformPoint(globalX, globalY) end
 ---
 ---Translating using whole numbers will prevent tearing/blurring of images and fonts draw after translating.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.translate)
+---
 ---@param dx number # The translation relative to the x-axis.
 ---@param dy number # The translation relative to the y-axis.
 function love.graphics.translate(dx, dy) end
 
 ---
 ---Validates shader code. Check if specified shader code does not contain any errors.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics.validateShader)
 ---
 ---@overload fun(gles: boolean, pixelcode: string, vertexcode: string):boolean, string
 ---@param gles boolean # Validate code as GLSL ES shader.
@@ -1066,6 +1370,9 @@ function love.graphics.validateShader(gles, code) end
 ---
 ---In versions prior to love.graphics.isSupported("canvas") could be used to check for support at runtime.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics)
+---
 ---@class love.Canvas: love.Texture, love.Drawable, love.Object
 local Canvas = {}
 
@@ -1076,6 +1383,9 @@ local Canvas = {}
 ---
 ---If the mipmap mode is set to 'auto', this function is automatically called inside love.graphics.setCanvas when switching from this Canvas to another Canvas or to the main screen.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Canvas:generateMipmaps)
+---
 function Canvas:generateMipmaps() end
 
 ---
@@ -1083,17 +1393,26 @@ function Canvas:generateMipmaps() end
 ---
 ---This may be different than the number used as an argument to love.graphics.newCanvas if the system running LÖVE doesn't support that number.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Canvas:getMSAA)
+---
 ---@return number samples # The number of multisample antialiasing samples used by the canvas when drawing to it.
 function Canvas:getMSAA() end
 
 ---
 ---Gets the MipmapMode this Canvas was created with.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Canvas:getMipmapMode)
+---
 ---@return love.MipmapMode mode # The mipmap mode this Canvas was created with.
 function Canvas:getMipmapMode() end
 
 ---
 ---Generates ImageData from the contents of the Canvas.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Canvas:newImageData)
 ---
 ---@overload fun(self: love.Canvas, slice: number, mipmap?: number, x: number, y: number, width: number, height: number):love.ImageData
 ---@return love.ImageData data # The new ImageData made from the Canvas' contents.
@@ -1114,17 +1433,26 @@ function Canvas:newImageData() end
 ---
 ---love.graphics.setCanvas()
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Canvas:renderTo)
+---
 ---@param func function # A function performing drawing operations.
 function Canvas:renderTo(func) end
 
 ---
 ---Superclass for all things that can be drawn on screen. This is an abstract type that can't be created directly.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics)
+---
 ---@class love.Drawable: love.Object
 local Drawable = {}
 
 ---
 ---Defines the shape of characters that can be drawn onto the screen.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics)
 ---
 ---@class love.Font: love.Object
 local Font = {}
@@ -1134,6 +1462,9 @@ local Font = {}
 ---
 ---The ascent spans the distance between the baseline and the top of the glyph that reaches farthest from the baseline.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Font:getAscent)
+---
 ---@return number ascent # The ascent of the Font in pixels.
 function Font:getAscent() end
 
@@ -1141,6 +1472,9 @@ function Font:getAscent() end
 ---Gets the baseline of the Font.
 ---
 ---Most scripts share the notion of a baseline: an imaginary horizontal line on which characters rest. In some scripts, parts of glyphs lie below the baseline.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Font:getBaseline)
 ---
 ---@return number baseline # The baseline of the Font in pixels.
 function Font:getBaseline() end
@@ -1152,6 +1486,9 @@ function Font:getBaseline() end
 ---
 ---The font size of TrueType fonts is scaled internally by the font's specified DPI scale factor. By default, LÖVE uses the screen's DPI scale factor when creating TrueType fonts.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Font:getDPIScale)
+---
 ---@return number dpiscale # The DPI scale factor of the Font.
 function Font:getDPIScale() end
 
@@ -1160,11 +1497,17 @@ function Font:getDPIScale() end
 ---
 ---The descent spans the distance between the baseline and the lowest descending glyph in a typeface.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Font:getDescent)
+---
 ---@return number descent # The descent of the Font in pixels.
 function Font:getDescent() end
 
 ---
 ---Gets the filter mode for a font.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Font:getFilter)
 ---
 ---@return love.FilterMode min # Filter mode used when minifying the font.
 ---@return love.FilterMode mag # Filter mode used when magnifying the font.
@@ -1176,6 +1519,9 @@ function Font:getFilter() end
 ---
 ---The height of the font is the size including any spacing; the height which it will need.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Font:getHeight)
+---
 ---@return number height # The height of the Font in pixels.
 function Font:getHeight() end
 
@@ -1183,6 +1529,9 @@ function Font:getHeight() end
 ---Gets the kerning between two characters in the Font.
 ---
 ---Kerning is normally handled automatically in love.graphics.print, Text objects, Font:getWidth, Font:getWrap, etc. This function is useful when stitching text together manually.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Font:getKerning)
 ---
 ---@overload fun(self: love.Font, leftglyph: number, rightglyph: number):number
 ---@param leftchar string # The left character.
@@ -1195,11 +1544,17 @@ function Font:getKerning(leftchar, rightchar) end
 ---
 ---This will be the value previously set by Font:setLineHeight, or 1.0 by default.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Font:getLineHeight)
+---
 ---@return number height # The current line height.
 function Font:getLineHeight() end
 
 ---
 ---Determines the maximum width (accounting for newlines) taken by the given string.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Font:getWidth)
 ---
 ---@param text string # A string.
 ---@return number width # The width of the text.
@@ -1210,6 +1565,9 @@ function Font:getWidth(text) end
 ---
 ---This function accounts for newlines correctly (i.e. '\n').
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Font:getWrap)
+---
 ---@param text string # The text that will be wrapped.
 ---@param wraplimit number # The maximum width in pixels of each line that ''text'' is allowed before wrapping.
 ---@return number width # The maximum width of the wrapped text.
@@ -1218,6 +1576,9 @@ function Font:getWrap(text, wraplimit) end
 
 ---
 ---Gets whether the Font can render a character or string.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Font:hasGlyphs)
 ---
 ---@overload fun(self: love.Font, character1: string, character2: string):boolean
 ---@overload fun(self: love.Font, codepoint1: number, codepoint2: number):boolean
@@ -1228,12 +1589,18 @@ function Font:hasGlyphs(text) end
 ---
 ---Sets the fallback fonts. When the Font doesn't contain a glyph, it will substitute the glyph from the next subsequent fallback Fonts. This is akin to setting a 'font stack' in Cascading Style Sheets (CSS).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Font:setFallbacks)
+---
 ---@param fallbackfont1 love.Font # The first fallback Font to use.
 ---@vararg love.Font # Additional fallback Fonts.
 function Font:setFallbacks(fallbackfont1, ...) end
 
 ---
 ---Sets the filter mode for a font.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Font:setFilter)
 ---
 ---@param min love.FilterMode # How to scale a font down.
 ---@param mag love.FilterMode # How to scale a font up.
@@ -1245,17 +1612,26 @@ function Font:setFilter(min, mag, anisotropy) end
 ---
 ---When rendering the font in lines the actual height will be determined by the line height multiplied by the height of the font. The default is 1.0.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Font:setLineHeight)
+---
 ---@param height number # The new line height.
 function Font:setLineHeight(height) end
 
 ---
 ---Drawable image type.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics)
+---
 ---@class love.Image: love.Texture, love.Drawable, love.Object
 local Image = {}
 
 ---
 ---Gets the flags used when the image was created.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Image:getFlags)
 ---
 ---@return table flags # A table with ImageFlag keys.
 function Image:getFlags() end
@@ -1265,11 +1641,17 @@ function Image:getFlags() end
 ---
 ---Compressed images take up less space in VRAM, and drawing a compressed image will generally be more efficient than drawing one created from raw pixel data.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Image:isCompressed)
+---
 ---@return boolean compressed # Whether the Image is stored as a compressed texture on the GPU.
 function Image:isCompressed() end
 
 ---
 ---Replace the contents of an Image.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Image:replacePixels)
 ---
 ---@param data love.ImageData # The new ImageData to replace the contents with.
 ---@param slice number # Which cubemap face, array index, or volume layer to replace, if applicable.
@@ -1282,11 +1664,17 @@ function Image:replacePixels(data, slice, mipmap, x, y, reloadmipmaps) end
 ---
 ---A 2D polygon mesh used for drawing arbitrary textured shapes.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics)
+---
 ---@class love.Mesh: love.Drawable, love.Object
 local Mesh = {}
 
 ---
 ---Attaches a vertex attribute from a different Mesh onto this Mesh, for use when drawing. This can be used to share vertex attribute data between several different Meshes.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:attachAttribute)
 ---
 ---@overload fun(self: love.Mesh, name: string, mesh: love.Mesh, step?: love.VertexAttributeStep, attachname?: string)
 ---@param name string # The name of the vertex attribute to attach.
@@ -1296,6 +1684,9 @@ function Mesh:attachAttribute(name, mesh) end
 ---
 ---Removes a previously attached vertex attribute from this Mesh.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:detachAttribute)
+---
 ---@param name string # The name of the attached vertex attribute to detach.
 ---@return boolean success # Whether the attribute was successfully detached.
 function Mesh:detachAttribute(name) end
@@ -1303,11 +1694,17 @@ function Mesh:detachAttribute(name) end
 ---
 ---Gets the mode used when drawing the Mesh.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:getDrawMode)
+---
 ---@return love.MeshDrawMode mode # The mode used when drawing the Mesh.
 function Mesh:getDrawMode() end
 
 ---
 ---Gets the range of vertices used when drawing the Mesh.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:getDrawRange)
 ---
 ---@return number min # The index of the first vertex used when drawing, or the index of the first value in the vertex map used if one is set for this Mesh.
 ---@return number max # The index of the last vertex used when drawing, or the index of the last value in the vertex map used if one is set for this Mesh.
@@ -1316,6 +1713,9 @@ function Mesh:getDrawRange() end
 ---
 ---Gets the texture (Image or Canvas) used when drawing the Mesh.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:getTexture)
+---
 ---@return love.Texture texture # The Image or Canvas to texture the Mesh with when drawing, or nil if none is set.
 function Mesh:getTexture() end
 
@@ -1323,6 +1723,9 @@ function Mesh:getTexture() end
 ---Gets the properties of a vertex in the Mesh.
 ---
 ---In versions prior to 11.0, color and byte component values were within the range of 0 to 255 instead of 0 to 1.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:getVertex)
 ---
 ---@overload fun(self: love.Mesh, index: number):number, number, number, number, number, number, number, number
 ---@param index number # The one-based index of the vertex you want to retrieve the information for.
@@ -1334,6 +1737,9 @@ function Mesh:getVertex(index) end
 ---
 ---Meshes without a custom vertex format specified in love.graphics.newMesh have position as their first attribute, texture coordinates as their second attribute, and color as their third attribute.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:getVertexAttribute)
+---
 ---@param vertexindex number # The index of the the vertex you want to retrieve the attribute for (one-based).
 ---@param attributeindex number # The index of the attribute within the vertex to be retrieved (one-based).
 ---@return number value1 # The value of the first component of the attribute.
@@ -1343,11 +1749,17 @@ function Mesh:getVertexAttribute(vertexindex, attributeindex) end
 ---
 ---Gets the total number of vertices in the Mesh.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:getVertexCount)
+---
 ---@return number count # The total number of vertices in the mesh.
 function Mesh:getVertexCount() end
 
 ---
 ---Gets the vertex format that the Mesh was created with.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:getVertexFormat)
 ---
 ---@return {attribute: table} format # The vertex format of the Mesh, which is a table containing tables for each vertex attribute the Mesh was created with, in the form of {attribute, ...}.
 function Mesh:getVertexFormat() end
@@ -1357,11 +1769,17 @@ function Mesh:getVertexFormat() end
 ---
 ---If no vertex map has been set previously via Mesh:setVertexMap, then this function will return nil in LÖVE 0.10.0+, or an empty table in 0.9.2 and older.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:getVertexMap)
+---
 ---@return table map # A table containing the list of vertex indices used when drawing.
 function Mesh:getVertexMap() end
 
 ---
 ---Gets whether a specific vertex attribute in the Mesh is enabled. Vertex data from disabled attributes is not used when drawing the Mesh.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:isAttributeEnabled)
 ---
 ---@param name string # The name of the vertex attribute to be checked.
 ---@return boolean enabled # Whether the vertex attribute is used when drawing this Mesh.
@@ -1370,6 +1788,9 @@ function Mesh:isAttributeEnabled(name) end
 ---
 ---Enables or disables a specific vertex attribute in the Mesh. Vertex data from disabled attributes is not used when drawing the Mesh.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:setAttributeEnabled)
+---
 ---@param name string # The name of the vertex attribute to enable or disable.
 ---@param enable boolean # Whether the vertex attribute is used when drawing this Mesh.
 function Mesh:setAttributeEnabled(name, enable) end
@@ -1377,11 +1798,17 @@ function Mesh:setAttributeEnabled(name, enable) end
 ---
 ---Sets the mode used when drawing the Mesh.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:setDrawMode)
+---
 ---@param mode love.MeshDrawMode # The mode to use when drawing the Mesh.
 function Mesh:setDrawMode(mode) end
 
 ---
 ---Restricts the drawn vertices of the Mesh to a subset of the total.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:setDrawRange)
 ---
 ---@overload fun(self: love.Mesh)
 ---@param start number # The index of the first vertex to use when drawing, or the index of the first value in the vertex map to use if one is set for this Mesh.
@@ -1391,6 +1818,9 @@ function Mesh:setDrawRange(start, count) end
 ---
 ---Sets the texture (Image or Canvas) used when drawing the Mesh.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:setTexture)
+---
 ---@overload fun(self: love.Mesh)
 ---@param texture love.Texture # The Image or Canvas to texture the Mesh with when drawing.
 function Mesh:setTexture(texture) end
@@ -1399,6 +1829,9 @@ function Mesh:setTexture(texture) end
 ---Sets the properties of a vertex in the Mesh.
 ---
 ---In versions prior to 11.0, color and byte component values were within the range of 0 to 255 instead of 0 to 1.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:setVertex)
 ---
 ---@overload fun(self: love.Mesh, index: number, vertex: table)
 ---@overload fun(self: love.Mesh, index: number, x: number, y: number, u: number, v: number, r?: number, g?: number, b?: number, a?: number)
@@ -1413,6 +1846,9 @@ function Mesh:setVertex(index, attributecomponent, ...) end
 ---
 ---Meshes without a custom vertex format specified in love.graphics.newMesh have position as their first attribute, texture coordinates as their second attribute, and color as their third attribute.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:setVertexAttribute)
+---
 ---@param vertexindex number # The index of the the vertex to be modified (one-based).
 ---@param attributeindex number # The index of the attribute within the vertex to be modified (one-based).
 ---@param value1 number # The new value for the first component of the attribute.
@@ -1425,6 +1861,9 @@ function Mesh:setVertexAttribute(vertexindex, attributeindex, value1, value2, ..
 ---
 ---The vertex map allows you to re-order or reuse vertices when drawing without changing the actual vertex parameters or duplicating vertices. It is especially useful when combined with different Mesh Draw Modes.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:setVertexMap)
+---
 ---@overload fun(self: love.Mesh, vi1: number, vi2: number, vi3: number)
 ---@overload fun(self: love.Mesh, data: love.Data, datatype: love.IndexDataType)
 ---@param map table # A table containing a list of vertex indices to use when drawing. Values must be in the range of Mesh:getVertexCount().
@@ -1432,6 +1871,9 @@ function Mesh:setVertexMap(map) end
 
 ---
 ---Replaces a range of vertices in the Mesh with new ones. The total number of vertices in a Mesh cannot be changed after it has been created. This is often more efficient than calling Mesh:setVertex in a loop.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Mesh:setVertices)
 ---
 ---@overload fun(self: love.Mesh, data: love.Data, startvertex?: number)
 ---@overload fun(self: love.Mesh, vertices: table)
@@ -1446,11 +1888,17 @@ function Mesh:setVertices(vertices, startvertex) end
 ---
 ---The particle system won't create any particles unless you call setParticleLifetime and setEmissionRate.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics)
+---
 ---@class love.ParticleSystem: love.Drawable, love.Object
 local ParticleSystem = {}
 
 ---
 ---Creates an identical copy of the ParticleSystem in the stopped state.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:clone)
 ---
 ---@return love.ParticleSystem particlesystem # The new identical copy of this ParticleSystem.
 function ParticleSystem:clone() end
@@ -1458,11 +1906,17 @@ function ParticleSystem:clone() end
 ---
 ---Emits a burst of particles from the particle emitter.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:emit)
+---
 ---@param numparticles number # The amount of particles to emit. The number of emitted particles will be truncated if the particle system's max buffer size is reached.
 function ParticleSystem:emit(numparticles) end
 
 ---
 ---Gets the maximum number of particles the ParticleSystem can have at once.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getBufferSize)
 ---
 ---@return number size # The maximum number of particles.
 function ParticleSystem:getBufferSize() end
@@ -1471,6 +1925,9 @@ function ParticleSystem:getBufferSize() end
 ---Gets the series of colors applied to the particle sprite.
 ---
 ---In versions prior to 11.0, color component values were within the range of 0 to 255 instead of 0 to 1.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getColors)
 ---
 ---@return number r1 # First color, red component (0-1).
 ---@return number g1 # First color, green component (0-1).
@@ -1489,17 +1946,26 @@ function ParticleSystem:getColors() end
 ---
 ---Gets the number of particles that are currently in the system.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getCount)
+---
 ---@return number count # The current number of live particles.
 function ParticleSystem:getCount() end
 
 ---
 ---Gets the direction of the particle emitter (in radians).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getDirection)
+---
 ---@return number direction # The direction of the emitter (radians).
 function ParticleSystem:getDirection() end
 
 ---
 ---Gets the area-based spawn parameters for the particles.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getEmissionArea)
 ---
 ---@return love.AreaSpreadDistribution distribution # The type of distribution for new particles.
 ---@return number dx # The maximum spawn distance from the emitter along the x-axis for uniform distribution, or the standard deviation along the x-axis for normal distribution.
@@ -1511,17 +1977,26 @@ function ParticleSystem:getEmissionArea() end
 ---
 ---Gets the amount of particles emitted per second.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getEmissionRate)
+---
 ---@return number rate # The amount of particles per second.
 function ParticleSystem:getEmissionRate() end
 
 ---
 ---Gets how long the particle system will emit particles (if -1 then it emits particles forever).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getEmitterLifetime)
+---
 ---@return number life # The lifetime of the emitter (in seconds).
 function ParticleSystem:getEmitterLifetime() end
 
 ---
 ---Gets the mode used when the ParticleSystem adds new particles.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getInsertMode)
 ---
 ---@return love.ParticleInsertMode mode # The mode used when the ParticleSystem adds new particles.
 function ParticleSystem:getInsertMode() end
@@ -1530,6 +2005,9 @@ function ParticleSystem:getInsertMode() end
 ---Gets the linear acceleration (acceleration along the x and y axes) for particles.
 ---
 ---Every particle created will accelerate along the x and y axes between xmin,ymin and xmax,ymax.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getLinearAcceleration)
 ---
 ---@return number xmin # The minimum acceleration along the x axis.
 ---@return number ymin # The minimum acceleration along the y axis.
@@ -1540,12 +2018,18 @@ function ParticleSystem:getLinearAcceleration() end
 ---
 ---Gets the amount of linear damping (constant deceleration) for particles.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getLinearDamping)
+---
 ---@return number min # The minimum amount of linear damping applied to particles.
 ---@return number max # The maximum amount of linear damping applied to particles.
 function ParticleSystem:getLinearDamping() end
 
 ---
 ---Gets the particle image's draw offset.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getOffset)
 ---
 ---@return number ox # The x coordinate of the particle image's draw offset.
 ---@return number oy # The y coordinate of the particle image's draw offset.
@@ -1554,12 +2038,18 @@ function ParticleSystem:getOffset() end
 ---
 ---Gets the lifetime of the particles.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getParticleLifetime)
+---
 ---@return number min # The minimum life of the particles (in seconds).
 ---@return number max # The maximum life of the particles (in seconds).
 function ParticleSystem:getParticleLifetime() end
 
 ---
 ---Gets the position of the emitter.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getPosition)
 ---
 ---@return number x # Position along x-axis.
 ---@return number y # Position along y-axis.
@@ -1568,11 +2058,17 @@ function ParticleSystem:getPosition() end
 ---
 ---Gets the series of Quads used for the particle sprites.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getQuads)
+---
 ---@return table quads # A table containing the Quads used.
 function ParticleSystem:getQuads() end
 
 ---
 ---Gets the radial acceleration (away from the emitter).
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getRadialAcceleration)
 ---
 ---@return number min # The minimum acceleration.
 ---@return number max # The maximum acceleration.
@@ -1581,6 +2077,9 @@ function ParticleSystem:getRadialAcceleration() end
 ---
 ---Gets the rotation of the image upon particle creation (in radians).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getRotation)
+---
 ---@return number min # The minimum initial angle (radians).
 ---@return number max # The maximum initial angle (radians).
 function ParticleSystem:getRotation() end
@@ -1588,11 +2087,17 @@ function ParticleSystem:getRotation() end
 ---
 ---Gets the amount of size variation (0 meaning no variation and 1 meaning full variation between start and end).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getSizeVariation)
+---
 ---@return number variation # The amount of variation (0 meaning no variation and 1 meaning full variation between start and end).
 function ParticleSystem:getSizeVariation() end
 
 ---
 ---Gets the series of sizes by which the sprite is scaled. 1.0 is normal size. The particle system will interpolate between each size evenly over the particle's lifetime.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getSizes)
 ---
 ---@return number size1 # The first size.
 ---@return number size2 # The second size.
@@ -1602,12 +2107,18 @@ function ParticleSystem:getSizes() end
 ---
 ---Gets the speed of the particles.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getSpeed)
+---
 ---@return number min # The minimum linear speed of the particles.
 ---@return number max # The maximum linear speed of the particles.
 function ParticleSystem:getSpeed() end
 
 ---
 ---Gets the spin of the sprite.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getSpin)
 ---
 ---@return number min # The minimum spin (radians per second).
 ---@return number max # The maximum spin (radians per second).
@@ -1617,17 +2128,26 @@ function ParticleSystem:getSpin() end
 ---
 ---Gets the amount of spin variation (0 meaning no variation and 1 meaning full variation between start and end).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getSpinVariation)
+---
 ---@return number variation # The amount of variation (0 meaning no variation and 1 meaning full variation between start and end).
 function ParticleSystem:getSpinVariation() end
 
 ---
 ---Gets the amount of directional spread of the particle emitter (in radians).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getSpread)
+---
 ---@return number spread # The spread of the emitter (radians).
 function ParticleSystem:getSpread() end
 
 ---
 ---Gets the tangential acceleration (acceleration perpendicular to the particle's direction).
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getTangentialAcceleration)
 ---
 ---@return number min # The minimum acceleration.
 ---@return number max # The maximum acceleration.
@@ -1636,11 +2156,17 @@ function ParticleSystem:getTangentialAcceleration() end
 ---
 ---Gets the texture (Image or Canvas) used for the particles.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:getTexture)
+---
 ---@return love.Texture texture # The Image or Canvas used for the particles.
 function ParticleSystem:getTexture() end
 
 ---
 ---Gets whether particle angles and rotations are relative to their velocities. If enabled, particles are aligned to the angle of their velocities and rotate relative to that angle.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:hasRelativeRotation)
 ---
 ---@return boolean enable # True if relative particle rotation is enabled, false if it's disabled.
 function ParticleSystem:hasRelativeRotation() end
@@ -1648,11 +2174,17 @@ function ParticleSystem:hasRelativeRotation() end
 ---
 ---Checks whether the particle system is actively emitting particles.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:isActive)
+---
 ---@return boolean active # True if system is active, false otherwise.
 function ParticleSystem:isActive() end
 
 ---
 ---Checks whether the particle system is paused.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:isPaused)
 ---
 ---@return boolean paused # True if system is paused, false otherwise.
 function ParticleSystem:isPaused() end
@@ -1660,11 +2192,17 @@ function ParticleSystem:isPaused() end
 ---
 ---Checks whether the particle system is stopped.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:isStopped)
+---
 ---@return boolean stopped # True if system is stopped, false otherwise.
 function ParticleSystem:isStopped() end
 
 ---
 ---Moves the position of the emitter. This results in smoother particle spawning behaviour than if ParticleSystem:setPosition is used every frame.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:moveTo)
 ---
 ---@param x number # Position along x-axis.
 ---@param y number # Position along y-axis.
@@ -1673,15 +2211,24 @@ function ParticleSystem:moveTo(x, y) end
 ---
 ---Pauses the particle emitter.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:pause)
+---
 function ParticleSystem:pause() end
 
 ---
 ---Resets the particle emitter, removing any existing particles and resetting the lifetime counter.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:reset)
+---
 function ParticleSystem:reset() end
 
 ---
 ---Sets the size of the buffer (the max allowed amount of particles in the system).
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setBufferSize)
 ---
 ---@param size number # The buffer size.
 function ParticleSystem:setBufferSize(size) end
@@ -1693,29 +2240,37 @@ function ParticleSystem:setBufferSize(size) end
 ---
 ---In versions prior to 11.0, color component values were within the range of 0 to 255 instead of 0 to 1.
 ---
----@overload fun(self: love.ParticleSystem, rgba1: table, rgba2: table, rgba8: table)
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setColors)
+---
 ---@param r1 number # First color, red component (0-1).
 ---@param g1 number # First color, green component (0-1).
 ---@param b1 number # First color, blue component (0-1).
----@param a1? number # First color, alpha component (0-1).
----@param r2? number # Second color, red component (0-1).
----@param g2? number # Second color, green component (0-1).
----@param b2? number # Second color, blue component (0-1).
----@param a2? number # Second color, alpha component (0-1).
----@param r8? number # Eighth color, red component (0-1).
----@param g8? number # Eighth color, green component (0-1).
----@param b8? number # Eighth color, blue component (0-1).
----@param a8? number # Eighth color, alpha component (0-1).
+---@param a1 number # First color, alpha component (0-1).
+---@param r2 number # Second color, red component (0-1).
+---@param g2 number # Second color, green component (0-1).
+---@param b2 number # Second color, blue component (0-1).
+---@param a2 number # Second color, alpha component (0-1).
+---@param r8 number # Eighth color, red component (0-1).
+---@param g8 number # Eighth color, green component (0-1).
+---@param b8 number # Eighth color, blue component (0-1).
+---@param a8 number # Eighth color, alpha component (0-1).
 function ParticleSystem:setColors(r1, g1, b1, a1, r2, g2, b2, a2, r8, g8, b8, a8) end
 
 ---
 ---Sets the direction the particles will be emitted in.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setDirection)
 ---
 ---@param direction number # The direction of the particles (in radians).
 function ParticleSystem:setDirection(direction) end
 
 ---
 ---Sets area-based spawn parameters for the particles. Newly created particles will spawn in an area around the emitter based on the parameters to this function.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setEmissionArea)
 ---
 ---@param distribution love.AreaSpreadDistribution # The type of distribution for new particles.
 ---@param dx number # The maximum spawn distance from the emitter along the x-axis for uniform distribution, or the standard deviation along the x-axis for normal distribution.
@@ -1727,17 +2282,26 @@ function ParticleSystem:setEmissionArea(distribution, dx, dy, angle, directionRe
 ---
 ---Sets the amount of particles emitted per second.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setEmissionRate)
+---
 ---@param rate number # The amount of particles per second.
 function ParticleSystem:setEmissionRate(rate) end
 
 ---
 ---Sets how long the particle system should emit particles (if -1 then it emits particles forever).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setEmitterLifetime)
+---
 ---@param life number # The lifetime of the emitter (in seconds).
 function ParticleSystem:setEmitterLifetime(life) end
 
 ---
 ---Sets the mode to use when the ParticleSystem adds new particles.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setInsertMode)
 ---
 ---@param mode love.ParticleInsertMode # The mode to use when the ParticleSystem adds new particles.
 function ParticleSystem:setInsertMode(mode) end
@@ -1746,6 +2310,9 @@ function ParticleSystem:setInsertMode(mode) end
 ---Sets the linear acceleration (acceleration along the x and y axes) for particles.
 ---
 ---Every particle created will accelerate along the x and y axes between xmin,ymin and xmax,ymax.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setLinearAcceleration)
 ---
 ---@param xmin number # The minimum acceleration along the x axis.
 ---@param ymin number # The minimum acceleration along the y axis.
@@ -1756,6 +2323,9 @@ function ParticleSystem:setLinearAcceleration(xmin, ymin, xmax, ymax) end
 ---
 ---Sets the amount of linear damping (constant deceleration) for particles.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setLinearDamping)
+---
 ---@param min number # The minimum amount of linear damping applied to particles.
 ---@param max? number # The maximum amount of linear damping applied to particles.
 function ParticleSystem:setLinearDamping(min, max) end
@@ -1765,12 +2335,18 @@ function ParticleSystem:setLinearDamping(min, max) end
 ---
 ---If this function is not used, the particles rotate around their center.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setOffset)
+---
 ---@param x number # The x coordinate of the rotation offset.
 ---@param y number # The y coordinate of the rotation offset.
 function ParticleSystem:setOffset(x, y) end
 
 ---
 ---Sets the lifetime of the particles.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setParticleLifetime)
 ---
 ---@param min number # The minimum life of the particles (in seconds).
 ---@param max? number # The maximum life of the particles (in seconds).
@@ -1779,12 +2355,18 @@ function ParticleSystem:setParticleLifetime(min, max) end
 ---
 ---Sets the position of the emitter.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setPosition)
+---
 ---@param x number # Position along x-axis.
 ---@param y number # Position along y-axis.
 function ParticleSystem:setPosition(x, y) end
 
 ---
 ---Sets a series of Quads to use for the particle sprites. Particles will choose a Quad from the list based on the particle's current lifetime, allowing for the use of animated sprite sheets with ParticleSystems.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setQuads)
 ---
 ---@overload fun(self: love.ParticleSystem, quads: table)
 ---@param quad1 love.Quad # The first Quad to use.
@@ -1794,6 +2376,9 @@ function ParticleSystem:setQuads(quad1, quad2) end
 ---
 ---Set the radial acceleration (away from the emitter).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setRadialAcceleration)
+---
 ---@param min number # The minimum acceleration.
 ---@param max? number # The maximum acceleration.
 function ParticleSystem:setRadialAcceleration(min, max) end
@@ -1801,11 +2386,17 @@ function ParticleSystem:setRadialAcceleration(min, max) end
 ---
 ---Sets whether particle angles and rotations are relative to their velocities. If enabled, particles are aligned to the angle of their velocities and rotate relative to that angle.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setRelativeRotation)
+---
 ---@param enable boolean # True to enable relative particle rotation, false to disable it.
 function ParticleSystem:setRelativeRotation(enable) end
 
 ---
 ---Sets the rotation of the image upon particle creation (in radians).
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setRotation)
 ---
 ---@param min number # The minimum initial angle (radians).
 ---@param max? number # The maximum initial angle (radians).
@@ -1813,6 +2404,9 @@ function ParticleSystem:setRotation(min, max) end
 
 ---
 ---Sets the amount of size variation (0 meaning no variation and 1 meaning full variation between start and end).
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setSizeVariation)
 ---
 ---@param variation number # The amount of variation (0 meaning no variation and 1 meaning full variation between start and end).
 function ParticleSystem:setSizeVariation(variation) end
@@ -1822,13 +2416,19 @@ function ParticleSystem:setSizeVariation(variation) end
 ---
 ---At least one size must be specified. A maximum of eight may be used.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setSizes)
+---
 ---@param size1 number # The first size.
----@param size2? number # The second size.
----@param size8? number # The eighth size.
+---@param size2 number # The second size.
+---@param size8 number # The eighth size.
 function ParticleSystem:setSizes(size1, size2, size8) end
 
 ---
 ---Sets the speed of the particles.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setSpeed)
 ---
 ---@param min number # The minimum linear speed of the particles.
 ---@param max? number # The maximum linear speed of the particles.
@@ -1837,6 +2437,9 @@ function ParticleSystem:setSpeed(min, max) end
 ---
 ---Sets the spin of the sprite.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setSpin)
+---
 ---@param min number # The minimum spin (radians per second).
 ---@param max? number # The maximum spin (radians per second).
 function ParticleSystem:setSpin(min, max) end
@@ -1844,17 +2447,26 @@ function ParticleSystem:setSpin(min, max) end
 ---
 ---Sets the amount of spin variation (0 meaning no variation and 1 meaning full variation between start and end).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setSpinVariation)
+---
 ---@param variation number # The amount of variation (0 meaning no variation and 1 meaning full variation between start and end).
 function ParticleSystem:setSpinVariation(variation) end
 
 ---
 ---Sets the amount of spread for the system.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setSpread)
+---
 ---@param spread number # The amount of spread (radians).
 function ParticleSystem:setSpread(spread) end
 
 ---
 ---Sets the tangential acceleration (acceleration perpendicular to the particle's direction).
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setTangentialAcceleration)
 ---
 ---@param min number # The minimum acceleration.
 ---@param max? number # The maximum acceleration.
@@ -1863,21 +2475,33 @@ function ParticleSystem:setTangentialAcceleration(min, max) end
 ---
 ---Sets the texture (Image or Canvas) to be used for the particles.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:setTexture)
+---
 ---@param texture love.Texture # An Image or Canvas to use for the particles.
 function ParticleSystem:setTexture(texture) end
 
 ---
 ---Starts the particle emitter.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:start)
+---
 function ParticleSystem:start() end
 
 ---
 ---Stops the particle emitter, resetting the lifetime counter.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:stop)
+---
 function ParticleSystem:stop() end
 
 ---
 ---Updates the particle system; moving, creating and killing particles.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleSystem:update)
 ---
 ---@param dt number # The time (seconds) since last frame.
 function ParticleSystem:update(dt) end
@@ -1887,11 +2511,17 @@ function ParticleSystem:update(dt) end
 ---
 ---Quads can be used to select part of a texture to draw. In this way, one large texture atlas can be loaded, and then split up into sub-images.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics)
+---
 ---@class love.Quad: love.Object
 local Quad = {}
 
 ---
 ---Gets reference texture dimensions initially specified in love.graphics.newQuad.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Quad:getTextureDimensions)
 ---
 ---@return number sw # The Texture width used by the Quad.
 ---@return number sh # The Texture height used by the Quad.
@@ -1899,6 +2529,9 @@ function Quad:getTextureDimensions() end
 
 ---
 ---Gets the current viewport of this Quad.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Quad:getViewport)
 ---
 ---@return number x # The top-left corner along the x-axis.
 ---@return number y # The top-left corner along the y-axis.
@@ -1908,6 +2541,9 @@ function Quad:getViewport() end
 
 ---
 ---Sets the texture coordinates according to a viewport.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Quad:setViewport)
 ---
 ---@param x number # The top-left corner along the x-axis.
 ---@param y number # The top-left corner along the y-axis.
@@ -1922,11 +2558,17 @@ function Quad:setViewport(x, y, w, h, sw, sh) end
 ---
 ---Potential uses for shaders include HDR/bloom, motion blur, grayscale/invert/sepia/any kind of color effect, reflection/refraction, distortions, bump mapping, and much more! Here is a collection of basic shaders and good starting point to learn: https://github.com/vrld/moonshine
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics)
+---
 ---@class love.Shader: love.Object
 local Shader = {}
 
 ---
 ---Returns any warning and error messages from compiling the shader code. This can be used for debugging your shaders if there's anything the graphics hardware doesn't like.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Shader:getWarnings)
 ---
 ---@return string warnings # Warning and error messages (if any).
 function Shader:getWarnings() end
@@ -1935,6 +2577,9 @@ function Shader:getWarnings() end
 ---Gets whether a uniform / extern variable exists in the Shader.
 ---
 ---If a graphics driver's shader compiler determines that a uniform / extern variable doesn't affect the final output of the shader, it may optimize the variable out. This function will return false in that case.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Shader:hasUniform)
 ---
 ---@param name string # The name of the uniform variable.
 ---@return boolean hasuniform # Whether the uniform exists in the shader and affects its final output.
@@ -1960,6 +2605,9 @@ function Shader:hasUniform(name) end
 ---shader:send('colors', {r1, g1, b1, a1},  {r2, g2, b2, a2},  {r3, g3, b3, a3},  {r4, g4, b4, a4})
 ---
 ---Uniform / extern variables are read-only in the shader code and remain constant until modified by a Shader:send call. Uniform variables can be accessed in both the Vertex and Pixel components of a shader, as long as the variable is declared in each.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Shader:send)
 ---
 ---@overload fun(self: love.Shader, name: string, vector: table, ...)
 ---@overload fun(self: love.Shader, name: string, matrix: table, ...)
@@ -1989,6 +2637,9 @@ function Shader:send(name, number, ...) end
 ---
 ---In versions prior to 11.0, color component values were within the range of 0 to 255 instead of 0 to 1.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Shader:sendColor)
+---
 ---@param name string # The name of the color extern variable to send to in the shader.
 ---@param color table # A table with red, green, blue, and optional alpha color components in the range of 1 to send to the extern as a vector.
 ---@vararg table # Additional colors to send in case the extern is an array. All colors need to be of the same size (e.g. only vec3's).
@@ -1999,11 +2650,17 @@ function Shader:sendColor(name, color, ...) end
 ---
 ---A SpriteBatch can be even more useful when the underlying image is a texture atlas (a single image file containing many independent images); by adding Quads to the batch, different sub-images from within the atlas can be drawn.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics)
+---
 ---@class love.SpriteBatch: love.Drawable, love.Object
 local SpriteBatch = {}
 
 ---
 ---Adds a sprite to the batch. Sprites are drawn in the order they are added.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/SpriteBatch:add)
 ---
 ---@overload fun(self: love.SpriteBatch, quad: love.Quad, x: number, y: number, r?: number, sx?: number, sy?: number, ox?: number, oy?: number, kx?: number, ky?: number):number
 ---@param x number # The position to draw the object (x-axis).
@@ -2020,6 +2677,9 @@ function SpriteBatch:add(x, y, r, sx, sy, ox, oy, kx, ky) end
 
 ---
 ---Adds a sprite to a batch created with an Array Texture.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/SpriteBatch:addLayer)
 ---
 ---@overload fun(self: love.SpriteBatch, layerindex: number, quad: love.Quad, x?: number, y?: number, r?: number, sx?: number, sy?: number, ox?: number, oy?: number, kx?: number, ky?: number):number
 ---@overload fun(self: love.SpriteBatch, layerindex: number, transform: love.Transform):number
@@ -2042,12 +2702,18 @@ function SpriteBatch:addLayer(layerindex, x, y, r, sx, sy, ox, oy, kx, ky) end
 ---
 ---Each sprite in a SpriteBatch has 4 vertices in the following order: top-left, bottom-left, top-right, bottom-right. The index returned by SpriteBatch:add (and used by SpriteBatch:set) can used to determine the first vertex of a specific sprite with the formula 1 + 4 * ( id - 1 ).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/SpriteBatch:attachAttribute)
+---
 ---@param name string # The name of the vertex attribute to attach.
 ---@param mesh love.Mesh # The Mesh to get the vertex attribute from.
 function SpriteBatch:attachAttribute(name, mesh) end
 
 ---
 ---Removes all sprites from the buffer.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/SpriteBatch:clear)
 ---
 function SpriteBatch:clear() end
 
@@ -2058,10 +2724,16 @@ function SpriteBatch:clear() end
 ---
 ---If this method is used, it generally shouldn't be called more than once (at most) between love.graphics.draw(spritebatch, ...) calls.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/SpriteBatch:flush)
+---
 function SpriteBatch:flush() end
 
 ---
 ---Gets the maximum number of sprites the SpriteBatch can hold.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/SpriteBatch:getBufferSize)
 ---
 ---@return number size # The maximum number of sprites the batch can hold.
 function SpriteBatch:getBufferSize() end
@@ -2073,6 +2745,9 @@ function SpriteBatch:getBufferSize() end
 ---
 ---In versions prior to 11.0, color component values were within the range of 0 to 255 instead of 0 to 1.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/SpriteBatch:getColor)
+---
 ---@return number r # The red component (0-1).
 ---@return number g # The green component (0-1).
 ---@return number b # The blue component (0-1).
@@ -2082,17 +2757,26 @@ function SpriteBatch:getColor() end
 ---
 ---Gets the number of sprites currently in the SpriteBatch.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/SpriteBatch:getCount)
+---
 ---@return number count # The number of sprites currently in the batch.
 function SpriteBatch:getCount() end
 
 ---
 ---Gets the texture (Image or Canvas) used by the SpriteBatch.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/SpriteBatch:getTexture)
+---
 ---@return love.Texture texture # The Image or Canvas used by the SpriteBatch.
 function SpriteBatch:getTexture() end
 
 ---
 ---Changes a sprite in the batch. This requires the sprite index returned by SpriteBatch:add or SpriteBatch:addLayer.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/SpriteBatch:set)
 ---
 ---@overload fun(self: love.SpriteBatch, spriteindex: number, quad: love.Quad, x: number, y: number, r?: number, sx?: number, sy?: number, ox?: number, oy?: number, kx?: number, ky?: number)
 ---@param spriteindex number # The index of the sprite that will be changed.
@@ -2114,6 +2798,9 @@ function SpriteBatch:set(spriteindex, x, y, r, sx, sy, ox, oy, kx, ky) end
 ---
 ---In version 0.9.2 and older, the global color set with love.graphics.setColor will not work on the SpriteBatch if any of the sprites has its own color.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/SpriteBatch:setColor)
+---
 ---@overload fun(self: love.SpriteBatch)
 ---@param r number # The amount of red.
 ---@param g number # The amount of green.
@@ -2124,6 +2811,9 @@ function SpriteBatch:setColor(r, g, b, a) end
 ---
 ---Restricts the drawn sprites in the SpriteBatch to a subset of the total.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/SpriteBatch:setDrawRange)
+---
 ---@overload fun(self: love.SpriteBatch)
 ---@param start number # The index of the first sprite to draw. Index 1 corresponds to the first sprite added with SpriteBatch:add.
 ---@param count number # The number of sprites to draw.
@@ -2131,6 +2821,9 @@ function SpriteBatch:setDrawRange(start, count) end
 
 ---
 ---Changes a sprite previously added with add or addLayer, in a batch created with an Array Texture.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/SpriteBatch:setLayer)
 ---
 ---@overload fun(self: love.SpriteBatch, spriteindex: number, layerindex: number, quad: love.Quad, x?: number, y?: number, r?: number, sx?: number, sy?: number, ox?: number, oy?: number, kx?: number, ky?: number)
 ---@overload fun(self: love.SpriteBatch, spriteindex: number, layerindex: number, transform: love.Transform)
@@ -2151,17 +2844,26 @@ function SpriteBatch:setLayer(spriteindex, layerindex, x, y, r, sx, sy, ox, oy, 
 ---
 ---Sets the texture (Image or Canvas) used for the sprites in the batch, when drawing.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/SpriteBatch:setTexture)
+---
 ---@param texture love.Texture # The new Image or Canvas to use for the sprites in the batch.
 function SpriteBatch:setTexture(texture) end
 
 ---
 ---Drawable text.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics)
+---
 ---@class love.Text: love.Drawable, love.Object
 local Text = {}
 
 ---
 ---Adds additional colored text to the Text object at the specified position.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Text:add)
 ---
 ---@overload fun(self: love.Text, coloredtext: table, x?: number, y?: number, angle?: number, sx?: number, sy?: number, ox?: number, oy?: number, kx?: number, ky?: number):number
 ---@param textstring string # The text to add to the object.
@@ -2182,6 +2884,9 @@ function Text:add(textstring, x, y, angle, sx, sy, ox, oy, kx, ky) end
 ---
 ---The word wrap limit is applied before any scaling, rotation, and other coordinate transformations. Therefore the amount of text per line stays constant given the same wrap limit, even if the scale arguments change.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Text:addf)
+---
 ---@overload fun(self: love.Text, coloredtext: table, wraplimit: number, align: love.AlignMode, x: number, y: number, angle?: number, sx?: number, sy?: number, ox?: number, oy?: number, kx?: number, ky?: number):number
 ---@param textstring string # The text to add to the object.
 ---@param wraplimit number # The maximum width in pixels of the text before it gets automatically wrapped to a new line.
@@ -2201,10 +2906,16 @@ function Text:addf(textstring, wraplimit, align, x, y, angle, sx, sy, ox, oy, kx
 ---
 ---Clears the contents of the Text object.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Text:clear)
+---
 function Text:clear() end
 
 ---
 ---Gets the width and height of the text in pixels.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Text:getDimensions)
 ---
 ---@overload fun(self: love.Text, index: number):number, number
 ---@return number width # The width of the text. If multiple sub-strings have been added with Text:add, the width of the last sub-string is returned.
@@ -2214,11 +2925,17 @@ function Text:getDimensions() end
 ---
 ---Gets the Font used with the Text object.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Text:getFont)
+---
 ---@return love.Font font # The font used with this Text object.
 function Text:getFont() end
 
 ---
 ---Gets the height of the text in pixels.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Text:getHeight)
 ---
 ---@overload fun(self: love.Text, index: number):number
 ---@return number height # The height of the text. If multiple sub-strings have been added with Text:add, the height of the last sub-string is returned.
@@ -2227,12 +2944,18 @@ function Text:getHeight() end
 ---
 ---Gets the width of the text in pixels.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Text:getWidth)
+---
 ---@overload fun(self: love.Text, index: number):number
 ---@return number width # The width of the text. If multiple sub-strings have been added with Text:add, the width of the last sub-string is returned.
 function Text:getWidth() end
 
 ---
 ---Replaces the contents of the Text object with a new unformatted string.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Text:set)
 ---
 ---@overload fun(self: love.Text, coloredtext: table)
 ---@param textstring string # The new string of text to use.
@@ -2241,11 +2964,17 @@ function Text:set(textstring) end
 ---
 ---Replaces the Font used with the text.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Text:setFont)
+---
 ---@param font love.Font # The new font to use with this Text object.
 function Text:setFont(font) end
 
 ---
 ---Replaces the contents of the Text object with a new formatted string.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Text:setf)
 ---
 ---@overload fun(self: love.Text, coloredtext: table, wraplimit: number, align: love.AlignMode)
 ---@param textstring string # The new string of text to use.
@@ -2255,6 +2984,9 @@ function Text:setf(textstring, wraplimit, align) end
 
 ---
 ---Superclass for drawable objects which represent a texture. All Textures can be drawn with Quads. This is an abstract type that can't be created directly.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics)
 ---
 ---@class love.Texture: love.Drawable, love.Object
 local Texture = {}
@@ -2266,11 +2998,17 @@ local Texture = {}
 ---
 ---For example, a texture with pixel dimensions of 100x100 with a DPI scale factor of 2 will be drawn as if it was 50x50. This is useful with high-dpi /  retina displays to easily allow swapping out higher or lower pixel density Images and Canvases without needing any extra manual scaling logic.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:getDPIScale)
+---
 ---@return number dpiscale # The DPI scale factor of the Texture.
 function Texture:getDPIScale() end
 
 ---
 ---Gets the depth of a Volume Texture. Returns 1 for 2D, Cubemap, and Array textures.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:getDepth)
 ---
 ---@return number depth # The depth of the volume Texture.
 function Texture:getDepth() end
@@ -2280,11 +3018,17 @@ function Texture:getDepth() end
 ---
 ---Depth texture comparison modes are advanced low-level functionality typically used with shadow mapping in 3D.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:getDepthSampleMode)
+---
 ---@return love.CompareMode compare # The comparison mode used when sampling from this texture in a shader, or nil if setDepthSampleMode has not been called on this Texture.
 function Texture:getDepthSampleMode() end
 
 ---
 ---Gets the width and height of the Texture.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:getDimensions)
 ---
 ---@return number width # The width of the Texture.
 ---@return number height # The height of the Texture.
@@ -2292,6 +3036,9 @@ function Texture:getDimensions() end
 
 ---
 ---Gets the filter mode of the Texture.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:getFilter)
 ---
 ---@return love.FilterMode min # Filter mode to use when minifying the texture (rendering it at a smaller size on-screen than its size in pixels).
 ---@return love.FilterMode mag # Filter mode to use when magnifying the texture (rendering it at a smaller size on-screen than its size in pixels).
@@ -2301,11 +3048,17 @@ function Texture:getFilter() end
 ---
 ---Gets the pixel format of the Texture.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:getFormat)
+---
 ---@return love.PixelFormat format # The pixel format the Texture was created with.
 function Texture:getFormat() end
 
 ---
 ---Gets the height of the Texture.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:getHeight)
 ---
 ---@return number height # The height of the Texture.
 function Texture:getHeight() end
@@ -2313,17 +3066,26 @@ function Texture:getHeight() end
 ---
 ---Gets the number of layers / slices in an Array Texture. Returns 1 for 2D, Cubemap, and Volume textures.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:getLayerCount)
+---
 ---@return number layers # The number of layers in the Array Texture.
 function Texture:getLayerCount() end
 
 ---
 ---Gets the number of mipmaps contained in the Texture. If the texture was not created with mipmaps, it will return 1.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:getMipmapCount)
+---
 ---@return number mipmaps # The number of mipmaps in the Texture.
 function Texture:getMipmapCount() end
 
 ---
 ---Gets the mipmap filter mode for a Texture. Prior to 11.0 this method only worked on Images.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:getMipmapFilter)
 ---
 ---@return love.FilterMode mode # The filter mode used in between mipmap levels. nil if mipmap filtering is not enabled.
 ---@return number sharpness # Value used to determine whether the image should use more or less detailed mipmap levels than normal when drawing.
@@ -2334,6 +3096,9 @@ function Texture:getMipmapFilter() end
 ---
 ---Texture:getDimensions gets the dimensions of the texture in units scaled by the texture's DPI scale factor, rather than pixels. Use getDimensions for calculations related to drawing the texture (calculating an origin offset, for example), and getPixelDimensions only when dealing specifically with pixels, for example when using Canvas:newImageData.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:getPixelDimensions)
+---
 ---@return number pixelwidth # The width of the Texture, in pixels.
 ---@return number pixelheight # The height of the Texture, in pixels.
 function Texture:getPixelDimensions() end
@@ -2343,6 +3108,9 @@ function Texture:getPixelDimensions() end
 ---
 ---DPI scale factor, rather than pixels. Use getHeight for calculations related to drawing the texture (calculating an origin offset, for example), and getPixelHeight only when dealing specifically with pixels, for example when using Canvas:newImageData.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:getPixelHeight)
+---
 ---@return number pixelheight # The height of the Texture, in pixels.
 function Texture:getPixelHeight() end
 
@@ -2351,17 +3119,26 @@ function Texture:getPixelHeight() end
 ---
 ---DPI scale factor, rather than pixels. Use getWidth for calculations related to drawing the texture (calculating an origin offset, for example), and getPixelWidth only when dealing specifically with pixels, for example when using Canvas:newImageData.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:getPixelWidth)
+---
 ---@return number pixelwidth # The width of the Texture, in pixels.
 function Texture:getPixelWidth() end
 
 ---
 ---Gets the type of the Texture.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:getTextureType)
+---
 ---@return love.TextureType texturetype # The type of the Texture.
 function Texture:getTextureType() end
 
 ---
 ---Gets the width of the Texture.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:getWidth)
 ---
 ---@return number width # The width of the Texture.
 function Texture:getWidth() end
@@ -2370,6 +3147,9 @@ function Texture:getWidth() end
 ---Gets the wrapping properties of a Texture.
 ---
 ---This function returns the currently set horizontal and vertical wrapping modes for the texture.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:getWrap)
 ---
 ---@return love.WrapMode horiz # Horizontal wrapping mode of the texture.
 ---@return love.WrapMode vert # Vertical wrapping mode of the texture.
@@ -2383,6 +3163,9 @@ function Texture:getWrap() end
 ---
 ---Non-readable Canvases can still be rendered to.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:isReadable)
+---
 ---@return boolean readable # Whether the Texture is readable.
 function Texture:isReadable() end
 
@@ -2393,11 +3176,17 @@ function Texture:isReadable() end
 ---
 ---Depth texture comparison can only be used with readable depth-formatted Canvases.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:setDepthSampleMode)
+---
 ---@param compare love.CompareMode # The comparison mode used when sampling from this texture in a shader.
 function Texture:setDepthSampleMode(compare) end
 
 ---
 ---Sets the filter mode of the Texture.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:setFilter)
 ---
 ---@param min love.FilterMode # Filter mode to use when minifying the texture (rendering it at a smaller size on-screen than its size in pixels).
 ---@param mag love.FilterMode # Filter mode to use when magnifying the texture (rendering it at a larger size on-screen than its size in pixels).
@@ -2413,6 +3202,9 @@ function Texture:setFilter(min, mag, anisotropy) end
 ---
 ---Due to hardware restrictions and driver bugs, in versions prior to 0.10.0 images that weren't loaded from a CompressedData must have power-of-two dimensions (64x64, 512x256, etc.) to use mipmaps.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:setMipmapFilter)
+---
 ---@overload fun(self: love.Texture)
 ---@param filtermode love.FilterMode # The filter mode to use in between mipmap levels. 'nearest' will often give better performance.
 ---@param sharpness? number # A positive sharpness value makes the texture use a more detailed mipmap level when drawing, at the expense of performance. A negative value does the reverse.
@@ -2425,6 +3217,9 @@ function Texture:setMipmapFilter(filtermode, sharpness) end
 ---
 ---Clamped textures appear only once (with the edges of the texture stretching to fill the extent of the Quad), whereas repeated ones repeat as many times as there is room in the Quad.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Texture:setWrap)
+---
 ---@param horiz love.WrapMode # Horizontal wrapping mode of the texture.
 ---@param vert? love.WrapMode # Vertical wrapping mode of the texture.
 ---@param depth? love.WrapMode # Wrapping mode for the z-axis of a Volume texture.
@@ -2433,11 +3228,17 @@ function Texture:setWrap(horiz, vert, depth) end
 ---
 ---A drawable video.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.graphics)
+---
 ---@class love.Video: love.Drawable, love.Object
 local Video = {}
 
 ---
 ---Gets the width and height of the Video in pixels.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Video:getDimensions)
 ---
 ---@return number width # The width of the Video.
 ---@return number height # The height of the Video.
@@ -2445,6 +3246,9 @@ function Video:getDimensions() end
 
 ---
 ---Gets the scaling filters used when drawing the Video.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Video:getFilter)
 ---
 ---@return love.FilterMode min # The filter mode used when scaling the Video down.
 ---@return love.FilterMode mag # The filter mode used when scaling the Video up.
@@ -2454,11 +3258,17 @@ function Video:getFilter() end
 ---
 ---Gets the height of the Video in pixels.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Video:getHeight)
+---
 ---@return number height # The height of the Video.
 function Video:getHeight() end
 
 ---
 ---Gets the audio Source used for playing back the video's audio. May return nil if the video has no audio, or if Video:setSource is called with a nil argument.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Video:getSource)
 ---
 ---@return love.Source source # The audio Source used for audio playback, or nil if the video has no audio.
 function Video:getSource() end
@@ -2466,11 +3276,17 @@ function Video:getSource() end
 ---
 ---Gets the VideoStream object used for decoding and controlling the video.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Video:getStream)
+---
 ---@return love.VideoStream stream # The VideoStream used for decoding and controlling the video.
 function Video:getStream() end
 
 ---
 ---Gets the width of the Video in pixels.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Video:getWidth)
 ---
 ---@return number width # The width of the Video.
 function Video:getWidth() end
@@ -2478,32 +3294,50 @@ function Video:getWidth() end
 ---
 ---Gets whether the Video is currently playing.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Video:isPlaying)
+---
 ---@return boolean playing # Whether the video is playing.
 function Video:isPlaying() end
 
 ---
 ---Pauses the Video.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Video:pause)
+---
 function Video:pause() end
 
 ---
 ---Starts playing the Video. In order for the video to appear onscreen it must be drawn with love.graphics.draw.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Video:play)
 ---
 function Video:play() end
 
 ---
 ---Rewinds the Video to the beginning.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Video:rewind)
+---
 function Video:rewind() end
 
 ---
 ---Sets the current playback position of the Video.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Video:seek)
 ---
 ---@param offset number # The time in seconds since the beginning of the Video.
 function Video:seek(offset) end
 
 ---
 ---Sets the scaling filters used when drawing the Video.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Video:setFilter)
 ---
 ---@param min love.FilterMode # The filter mode used when scaling the Video down.
 ---@param mag love.FilterMode # The filter mode used when scaling the Video up.
@@ -2513,17 +3347,26 @@ function Video:setFilter(min, mag, anisotropy) end
 ---
 ---Sets the audio Source used for playing back the video's audio. The audio Source also controls playback speed and synchronization.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Video:setSource)
+---
 ---@param source? love.Source # The audio Source used for audio playback, or nil to disable audio synchronization.
 function Video:setSource(source) end
 
 ---
 ---Gets the current playback position of the Video.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Video:tell)
+---
 ---@return number seconds # The time in seconds since the beginning of the Video.
 function Video:tell() end
 
 ---
 ---Text alignment.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/AlignMode)
 ---
 ---@alias love.AlignMode
 ---
@@ -2546,6 +3389,9 @@ function Video:tell() end
 ---
 ---Different types of arcs that can be drawn.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ArcType)
+---
 ---@alias love.ArcType
 ---
 ---The arc is drawn like a slice of pie, with the arc circle connected to the center at its end-points.
@@ -2562,6 +3408,9 @@ function Video:tell() end
 
 ---
 ---Types of particle area spread distribution.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/AreaSpreadDistribution)
 ---
 ---@alias love.AreaSpreadDistribution
 ---
@@ -2592,6 +3441,9 @@ function Video:tell() end
 ---
 ---Different ways alpha affects color blending. See BlendMode and the BlendMode Formulas for additional notes.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/BlendAlphaMode)
+---
 ---@alias love.BlendAlphaMode
 ---
 ---The RGB values of what's drawn are multiplied by the alpha values of those colors during blending. This is the default alpha mode.
@@ -2604,6 +3456,9 @@ function Video:tell() end
 
 ---
 ---Different ways to do color blending. See BlendAlphaMode and the BlendMode Formulas for additional notes.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/BlendMode)
 ---
 ---@alias love.BlendMode
 ---
@@ -2658,6 +3513,9 @@ function Video:tell() end
 ---
 ---Different types of per-pixel stencil test and depth test comparisons. The pixels of an object will be drawn if the comparison succeeds, for each pixel that the object touches.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/CompareMode)
+---
 ---@alias love.CompareMode
 ---
 ---* stencil tests: the stencil value of the pixel must be equal to the supplied value.
@@ -2701,6 +3559,9 @@ function Video:tell() end
 ---
 ---How Mesh geometry is culled when rendering.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/CullMode)
+---
 ---@alias love.CullMode
 ---
 ---Back-facing triangles in Meshes are culled (not rendered). The vertex order of a triangle determines whether it is back- or front-facing.
@@ -2718,6 +3579,9 @@ function Video:tell() end
 ---
 ---Controls whether shapes are drawn as an outline, or filled.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/DrawMode)
+---
 ---@alias love.DrawMode
 ---
 ---Draw filled shape.
@@ -2731,6 +3595,9 @@ function Video:tell() end
 ---
 ---How the image is filtered when scaling.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/FilterMode)
+---
 ---@alias love.FilterMode
 ---
 ---Scale image with linear interpolation.
@@ -2743,6 +3610,9 @@ function Video:tell() end
 
 ---
 ---Graphics features that can be checked for with love.graphics.getSupported.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/GraphicsFeature)
 ---
 ---@alias love.GraphicsFeature
 ---
@@ -2781,6 +3651,9 @@ function Video:tell() end
 ---
 ---Types of system-dependent graphics limits checked for using love.graphics.getSystemLimits.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/GraphicsLimit)
+---
 ---@alias love.GraphicsLimit
 ---
 ---The maximum size of points.
@@ -2818,6 +3691,9 @@ function Video:tell() end
 ---
 ---Vertex map datatype for Data variant of Mesh:setVertexMap.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/IndexDataType)
+---
 ---@alias love.IndexDataType
 ---
 ---The vertex map is array of unsigned word (16-bit).
@@ -2830,6 +3706,9 @@ function Video:tell() end
 
 ---
 ---Line join style.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/LineJoin)
 ---
 ---@alias love.LineJoin
 ---
@@ -2848,6 +3727,9 @@ function Video:tell() end
 ---
 ---The styles in which lines are drawn.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/LineStyle)
+---
 ---@alias love.LineStyle
 ---
 ---Draw rough lines.
@@ -2860,6 +3742,9 @@ function Video:tell() end
 
 ---
 ---How a Mesh's vertices are used when drawing.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/MeshDrawMode)
 ---
 ---@alias love.MeshDrawMode
 ---
@@ -2882,6 +3767,9 @@ function Video:tell() end
 ---
 ---Controls whether a Canvas has mipmaps, and its behaviour when it does.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/MipmapMode)
+---
 ---@alias love.MipmapMode
 ---
 ---The Canvas has no mipmaps.
@@ -2898,6 +3786,9 @@ function Video:tell() end
 
 ---
 ---How newly created particles are added to the ParticleSystem.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ParticleInsertMode)
 ---
 ---@alias love.ParticleInsertMode
 ---
@@ -2916,6 +3807,9 @@ function Video:tell() end
 ---
 ---Usage hints for SpriteBatches and Meshes to optimize data storage and access.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/SpriteBatchUsage)
+---
 ---@alias love.SpriteBatchUsage
 ---
 ---The object's data will change occasionally during its lifetime. 
@@ -2933,6 +3827,9 @@ function Video:tell() end
 ---
 ---Graphics state stack types used with love.graphics.push.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/StackType)
+---
 ---@alias love.StackType
 ---
 ---The transformation stack (love.graphics.translate, love.graphics.rotate, etc.)
@@ -2945,6 +3842,9 @@ function Video:tell() end
 
 ---
 ---How a stencil function modifies the stencil values of pixels it touches.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/StencilAction)
 ---
 ---@alias love.StencilAction
 ---
@@ -2975,6 +3875,9 @@ function Video:tell() end
 ---
 ---Types of textures (2D, cubemap, etc.)
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/TextureType)
+---
 ---@alias love.TextureType
 ---
 ---Regular 2D texture with width and height.
@@ -2998,6 +3901,9 @@ function Video:tell() end
 ---
 ---Per-instance attributes can be used to render a Mesh many times with different positions, colors, or other attributes via a single love.graphics.drawInstanced call, without using the love_InstanceID vertex shader variable.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/VertexAttributeStep)
+---
 ---@alias love.VertexAttributeStep
 ---
 ---The vertex attribute will have a unique value for each vertex in the Mesh.
@@ -3011,6 +3917,9 @@ function Video:tell() end
 ---
 ---How Mesh geometry vertices are ordered.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/VertexWinding)
+---
 ---@alias love.VertexWinding
 ---
 ---Clockwise.
@@ -3023,6 +3932,9 @@ function Video:tell() end
 
 ---
 ---How the image wraps inside a Quad with a larger quad size than image size. This also affects how Meshes with texture coordinates which are outside the range of 1 are drawn, and the color returned by the Texel Shader function when using it to sample from texture coordinates outside of the range of 1.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/WrapMode)
 ---
 ---@alias love.WrapMode
 ---

--- a/meta/3rd/love2d/library/love/image.lua
+++ b/meta/3rd/love2d/library/love/image.lua
@@ -3,11 +3,17 @@
 ---
 ---Provides an interface to decode encoded image data.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.image)
+---
 ---@class love.image
 love.image = {}
 
 ---
 ---Determines whether a file can be loaded as CompressedImageData.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.image.isCompressed)
 ---
 ---@overload fun(fileData: love.FileData):boolean
 ---@param filename string # The filename of the potentially compressed image file.
@@ -17,6 +23,9 @@ function love.image.isCompressed(filename) end
 ---
 ---Create a new CompressedImageData object from a compressed image file. LÖVE supports several compressed texture formats, enumerated in the CompressedImageFormat page.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.image.newCompressedData)
+---
 ---@overload fun(fileData: love.FileData):love.CompressedImageData
 ---@param filename string # The filename of the compressed image file.
 ---@return love.CompressedImageData compressedImageData # The new CompressedImageData object.
@@ -24,6 +33,9 @@ function love.image.newCompressedData(filename) end
 
 ---
 ---Creates a new ImageData object.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.image.newImageData)
 ---
 ---@overload fun(width: number, height: number, format?: love.PixelFormat, data?: string):love.ImageData
 ---@overload fun(width: number, height: number, data: string):love.ImageData
@@ -41,11 +53,17 @@ function love.image.newImageData(width, height) end
 ---
 ---You can't draw CompressedImageData directly to the screen. See Image for that.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.image)
+---
 ---@class love.CompressedImageData: love.Data, love.Object
 local CompressedImageData = {}
 
 ---
 ---Gets the width and height of the CompressedImageData.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/CompressedImageData:getDimensions)
 ---
 ---@overload fun(self: love.CompressedImageData, level: number):number, number
 ---@return number width # The width of the CompressedImageData.
@@ -55,11 +73,17 @@ function CompressedImageData:getDimensions() end
 ---
 ---Gets the format of the CompressedImageData.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/CompressedImageData:getFormat)
+---
 ---@return love.CompressedImageFormat format # The format of the CompressedImageData.
 function CompressedImageData:getFormat() end
 
 ---
 ---Gets the height of the CompressedImageData.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/CompressedImageData:getHeight)
 ---
 ---@overload fun(self: love.CompressedImageData, level: number):number
 ---@return number height # The height of the CompressedImageData.
@@ -68,11 +92,17 @@ function CompressedImageData:getHeight() end
 ---
 ---Gets the number of mipmap levels in the CompressedImageData. The base mipmap level (original image) is included in the count.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/CompressedImageData:getMipmapCount)
+---
 ---@return number mipmaps # The number of mipmap levels stored in the CompressedImageData.
 function CompressedImageData:getMipmapCount() end
 
 ---
 ---Gets the width of the CompressedImageData.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/CompressedImageData:getWidth)
 ---
 ---@overload fun(self: love.CompressedImageData, level: number):number
 ---@return number width # The width of the CompressedImageData.
@@ -83,11 +113,17 @@ function CompressedImageData:getWidth() end
 ---
 ---You can't draw ImageData directly to screen. See Image for that.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.image)
+---
 ---@class love.ImageData: love.Data, love.Object
 local ImageData = {}
 
 ---
 ---Encodes the ImageData and optionally writes it to the save directory.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ImageData:encode)
 ---
 ---@overload fun(self: love.ImageData, outFile: string)
 ---@overload fun(self: love.ImageData, outFile: string, format: love.ImageFormat)
@@ -99,12 +135,18 @@ function ImageData:encode(format, filename) end
 ---
 ---Gets the width and height of the ImageData in pixels.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ImageData:getDimensions)
+---
 ---@return number width # The width of the ImageData in pixels.
 ---@return number height # The height of the ImageData in pixels.
 function ImageData:getDimensions() end
 
 ---
 ---Gets the height of the ImageData in pixels.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ImageData:getHeight)
 ---
 ---@return number height # The height of the ImageData in pixels.
 function ImageData:getHeight() end
@@ -116,6 +158,9 @@ function ImageData:getHeight() end
 ---
 ---In versions prior to 11.0, color component values were within the range of 0 to 255 instead of 0 to 1.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ImageData:getPixel)
+---
 ---@param x number # The position of the pixel on the x-axis.
 ---@param y number # The position of the pixel on the y-axis.
 ---@return number r # The red component (0-1).
@@ -126,6 +171,9 @@ function ImageData:getPixel(x, y) end
 
 ---
 ---Gets the width of the ImageData in pixels.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ImageData:getWidth)
 ---
 ---@return number width # The width of the ImageData in pixels.
 function ImageData:getWidth() end
@@ -151,6 +199,9 @@ function ImageData:getWidth() end
 ---
 ---In versions prior to 11.0, color component values were within the range of 0 to 255 instead of 0 to 1.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ImageData:mapPixel)
+---
 ---@param pixelFunction function # Function to apply to every pixel.
 ---@param x? number # The x-axis of the top-left corner of the area within the ImageData to apply the function to.
 ---@param y? number # The y-axis of the top-left corner of the area within the ImageData to apply the function to.
@@ -160,6 +211,9 @@ function ImageData:mapPixel(pixelFunction, x, y, width, height) end
 
 ---
 ---Paste into ImageData from another source ImageData.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ImageData:paste)
 ---
 ---@param source love.ImageData # Source ImageData from which to copy.
 ---@param dx number # Destination top-left position on x-axis.
@@ -177,6 +231,9 @@ function ImageData:paste(source, dx, dy, sx, sy, sw, sh) end
 ---
 ---In versions prior to 11.0, color component values were within the range of 0 to 255 instead of 0 to 1.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ImageData:setPixel)
+---
 ---@param x number # The position of the pixel on the x-axis.
 ---@param y number # The position of the pixel on the y-axis.
 ---@param r number # The red component (0-1).
@@ -188,6 +245,9 @@ function ImageData:setPixel(x, y, r, g, b, a) end
 ---
 ---Gets the pixel format of the ImageData.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ImageData:getFormat)
+---
 ---@return love.PixelFormat format # The pixel format the ImageData was created with.
 function ImageData:getFormat() end
 
@@ -195,6 +255,9 @@ function ImageData:getFormat() end
 ---Compressed image data formats. Here and here are a couple overviews of many of the formats.
 ---
 ---Unlike traditional PNG or jpeg, these formats stay compressed in RAM and in the graphics card's VRAM. This is good for saving memory space as well as improving performance, since the graphics card will be able to keep more of the image's pixels in its fast-access cache when drawing it.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/CompressedImageFormat)
 ---
 ---@alias love.CompressedImageFormat
 ---
@@ -345,6 +408,9 @@ function ImageData:getFormat() end
 ---
 ---Encoded image formats.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ImageFormat)
+---
 ---@alias love.ImageFormat
 ---
 ---Targa image format.
@@ -365,6 +431,9 @@ function ImageData:getFormat() end
 
 ---
 ---Pixel formats for Textures, ImageData, and CompressedImageData.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/PixelFormat)
 ---
 ---@alias love.PixelFormat
 ---

--- a/meta/3rd/love2d/library/love/joystick.lua
+++ b/meta/3rd/love2d/library/love/joystick.lua
@@ -3,6 +3,9 @@
 ---
 ---Provides an interface to the user's joystick.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.joystick)
+---
 ---@class love.joystick
 love.joystick = {}
 
@@ -11,6 +14,9 @@ love.joystick = {}
 ---
 ---The mapping string contains binding information used to map the Joystick's buttons an axes to the standard gamepad layout, and can be used later with love.joystick.loadGamepadMappings.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.joystick.getGamepadMappingString)
+---
 ---@param guid string # The GUID value to get the mapping string for.
 ---@return string mappingstring # A string containing the Joystick's gamepad mappings, or nil if the GUID is not recognized as a gamepad.
 function love.joystick.getGamepadMappingString(guid) end
@@ -18,11 +24,17 @@ function love.joystick.getGamepadMappingString(guid) end
 ---
 ---Gets the number of connected joysticks.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.joystick.getJoystickCount)
+---
 ---@return number joystickcount # The number of connected joysticks.
 function love.joystick.getJoystickCount() end
 
 ---
 ---Gets a list of connected Joysticks.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.joystick.getJoysticks)
 ---
 ---@return table joysticks # The list of currently connected Joysticks.
 function love.joystick.getJoysticks() end
@@ -32,6 +44,9 @@ function love.joystick.getJoysticks() end
 ---
 ---It also recognizes any SDL gamecontroller mapping string, such as those created with Steam's Big Picture controller configure interface, or this nice database. If a new mapping is loaded for an already known controller GUID, the later version will overwrite the one currently loaded.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.joystick.loadGamepadMappings)
+---
 ---@overload fun(mappings: string)
 ---@param filename string # The filename to load the mappings string from.
 function love.joystick.loadGamepadMappings(filename) end
@@ -40,6 +55,9 @@ function love.joystick.loadGamepadMappings(filename) end
 ---Saves the virtual gamepad mappings of all recognized as gamepads and have either been recently used or their gamepad bindings have been modified.
 ---
 ---The mappings are stored as a string for use with love.joystick.loadGamepadMappings.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.joystick.saveGamepadMappings)
 ---
 ---@overload fun():string
 ---@param filename string # The filename to save the mappings string to.
@@ -53,6 +71,9 @@ function love.joystick.saveGamepadMappings(filename) end
 ---
 ---The virtual gamepad buttons and axes are designed around the Xbox 360 controller layout.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.joystick.setGamepadMapping)
+---
 ---@overload fun(guid: string, axis: love.GamepadAxis, inputtype: love.JoystickInputType, inputindex: number, hatdir?: love.JoystickHat):boolean
 ---@param guid string # The OS-dependent GUID for the type of Joystick the binding will affect.
 ---@param button love.GamepadButton # The virtual gamepad button to bind.
@@ -65,11 +86,17 @@ function love.joystick.setGamepadMapping(guid, button, inputtype, inputindex, ha
 ---
 ---Represents a physical joystick.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.joystick)
+---
 ---@class love.Joystick: love.Object
 local Joystick = {}
 
 ---
 ---Gets the direction of each axis.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:getAxes)
 ---
 ---@return number axisDir1 # Direction of axis1.
 ---@return number axisDir2 # Direction of axis2.
@@ -79,6 +106,9 @@ function Joystick:getAxes() end
 ---
 ---Gets the direction of an axis.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:getAxis)
+---
 ---@param axis number # The index of the axis to be checked.
 ---@return number direction # Current value of the axis.
 function Joystick:getAxis(axis) end
@@ -86,11 +116,17 @@ function Joystick:getAxis(axis) end
 ---
 ---Gets the number of axes on the joystick.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:getAxisCount)
+---
 ---@return number axes # The number of axes available.
 function Joystick:getAxisCount() end
 
 ---
 ---Gets the number of buttons on the joystick.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:getButtonCount)
 ---
 ---@return number buttons # The number of buttons available.
 function Joystick:getButtonCount() end
@@ -100,6 +136,9 @@ function Joystick:getButtonCount() end
 ---
 ---Can be used to show different icons, etc. for different gamepads.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:getDeviceInfo)
+---
 ---@return number vendorID # The USB vendor ID of the joystick.
 ---@return number productID # The USB product ID of the joystick.
 ---@return number productVersion # The product version of the joystick.
@@ -108,11 +147,17 @@ function Joystick:getDeviceInfo() end
 ---
 ---Gets a stable GUID unique to the type of the physical joystick which does not change over time. For example, all Sony Dualshock 3 controllers in OS X have the same GUID. The value is platform-dependent.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:getGUID)
+---
 ---@return string guid # The Joystick type's OS-dependent unique identifier.
 function Joystick:getGUID() end
 
 ---
 ---Gets the direction of a virtual gamepad axis. If the Joystick isn't recognized as a gamepad or isn't connected, this function will always return 0.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:getGamepadAxis)
 ---
 ---@param axis love.GamepadAxis # The virtual axis to be checked.
 ---@return number direction # Current value of the axis.
@@ -120,6 +165,9 @@ function Joystick:getGamepadAxis(axis) end
 
 ---
 ---Gets the button, axis or hat that a virtual gamepad input is bound to.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:getGamepadMapping)
 ---
 ---@overload fun(self: love.Joystick, button: love.GamepadButton):love.JoystickInputType, number, love.JoystickHat
 ---@param axis love.GamepadAxis # The virtual gamepad axis to get the binding for.
@@ -133,11 +181,17 @@ function Joystick:getGamepadMapping(axis) end
 ---
 ---The mapping string contains binding information used to map the Joystick's buttons an axes to the standard gamepad layout, and can be used later with love.joystick.loadGamepadMappings.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:getGamepadMappingString)
+---
 ---@return string mappingstring # A string containing the Joystick's gamepad mappings, or nil if the Joystick is not recognized as a gamepad.
 function Joystick:getGamepadMappingString() end
 
 ---
 ---Gets the direction of the Joystick's hat.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:getHat)
 ---
 ---@param hat number # The index of the hat to be checked.
 ---@return love.JoystickHat direction # The direction the hat is pushed.
@@ -146,11 +200,17 @@ function Joystick:getHat(hat) end
 ---
 ---Gets the number of hats on the joystick.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:getHatCount)
+---
 ---@return number hats # How many hats the joystick has.
 function Joystick:getHatCount() end
 
 ---
 ---Gets the joystick's unique identifier. The identifier will remain the same for the life of the game, even when the Joystick is disconnected and reconnected, but it '''will''' change when the game is re-launched.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:getID)
 ---
 ---@return number id # The Joystick's unique identifier. Remains the same as long as the game is running.
 ---@return number instanceid # Unique instance identifier. Changes every time the Joystick is reconnected. nil if the Joystick is not connected.
@@ -159,11 +219,17 @@ function Joystick:getID() end
 ---
 ---Gets the name of the joystick.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:getName)
+---
 ---@return string name # The name of the joystick.
 function Joystick:getName() end
 
 ---
 ---Gets the current vibration motor strengths on a Joystick with rumble support.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:getVibration)
 ---
 ---@return number left # Current strength of the left vibration motor on the Joystick.
 ---@return number right # Current strength of the right vibration motor on the Joystick.
@@ -172,6 +238,9 @@ function Joystick:getVibration() end
 ---
 ---Gets whether the Joystick is connected.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:isConnected)
+---
 ---@return boolean connected # True if the Joystick is currently connected, false otherwise.
 function Joystick:isConnected() end
 
@@ -179,6 +248,9 @@ function Joystick:isConnected() end
 ---Checks if a button on the Joystick is pressed.
 ---
 ---LÖVE 0.9.0 had a bug which required the button indices passed to Joystick:isDown to be 0-based instead of 1-based, for example button 1 would be 0 for this function. It was fixed in 0.9.1.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:isDown)
 ---
 ---@param buttonN number # The index of a button to check.
 ---@return boolean anyDown # True if any supplied button is down, false if not.
@@ -189,11 +261,17 @@ function Joystick:isDown(buttonN) end
 ---
 ---LÖVE automatically recognizes most popular controllers with a similar layout to the Xbox 360 controller as gamepads, but you can add more with love.joystick.setGamepadMapping.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:isGamepad)
+---
 ---@return boolean isgamepad # True if the Joystick is recognized as a gamepad, false otherwise.
 function Joystick:isGamepad() end
 
 ---
 ---Checks if a virtual gamepad button on the Joystick is pressed. If the Joystick is not recognized as a Gamepad or isn't connected, then this function will always return false.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:isGamepadDown)
 ---
 ---@param buttonN love.GamepadButton # The gamepad button to check.
 ---@return boolean anyDown # True if any supplied button is down, false if not.
@@ -202,11 +280,17 @@ function Joystick:isGamepadDown(buttonN) end
 ---
 ---Gets whether the Joystick supports vibration.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:isVibrationSupported)
+---
 ---@return boolean supported # True if rumble / force feedback vibration is supported on this Joystick, false if not.
 function Joystick:isVibrationSupported() end
 
 ---
 ---Sets the vibration motor speeds on a Joystick with rumble support. Most common gamepads have this functionality, although not all drivers give proper support. Use Joystick:isVibrationSupported to check.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Joystick:setVibration)
 ---
 ---@overload fun(self: love.Joystick):boolean
 ---@overload fun(self: love.Joystick, left: number, right: number, duration?: number):boolean
@@ -217,6 +301,9 @@ function Joystick:setVibration(left, right) end
 
 ---
 ---Virtual gamepad axes.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/GamepadAxis)
 ---
 ---@alias love.GamepadAxis
 ---
@@ -246,6 +333,9 @@ function Joystick:setVibration(left, right) end
 
 ---
 ---Virtual gamepad buttons.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/GamepadButton)
 ---
 ---@alias love.GamepadButton
 ---
@@ -312,6 +402,9 @@ function Joystick:setVibration(left, right) end
 ---
 ---Joystick hat positions.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/JoystickHat)
+---
 ---@alias love.JoystickHat
 ---
 ---Centered
@@ -352,6 +445,9 @@ function Joystick:setVibration(left, right) end
 
 ---
 ---Types of Joystick inputs.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/JoystickInputType)
 ---
 ---@alias love.JoystickInputType
 ---

--- a/meta/3rd/love2d/library/love/keyboard.lua
+++ b/meta/3rd/love2d/library/love/keyboard.lua
@@ -3,6 +3,9 @@
 ---
 ---Provides an interface to the user's keyboard.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.keyboard)
+---
 ---@class love.keyboard
 love.keyboard = {}
 
@@ -12,6 +15,9 @@ love.keyboard = {}
 ---Unlike key constants, Scancodes are keyboard layout-independent. For example the scancode 'w' will be generated if the key in the same place as the 'w' key on an American keyboard is pressed, no matter what the key is labelled or what the user's operating system settings are.
 ---
 ---Scancodes are useful for creating default controls that have the same physical locations on on all systems.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.keyboard.getKeyFromScancode)
 ---
 ---@param scancode love.Scancode # The scancode to get the key from.
 ---@return love.KeyConstant key # The key corresponding to the given scancode, or 'unknown' if the scancode doesn't map to a KeyConstant on the current system.
@@ -24,6 +30,9 @@ function love.keyboard.getKeyFromScancode(scancode) end
 ---
 ---Scancodes are useful for creating default controls that have the same physical locations on on all systems.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.keyboard.getScancodeFromKey)
+---
 ---@param key love.KeyConstant # The key to get the scancode from.
 ---@return love.Scancode scancode # The scancode corresponding to the given key, or 'unknown' if the given key has no known physical representation on the current system.
 function love.keyboard.getScancodeFromKey(key) end
@@ -31,11 +40,17 @@ function love.keyboard.getScancodeFromKey(key) end
 ---
 ---Gets whether key repeat is enabled.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.keyboard.hasKeyRepeat)
+---
 ---@return boolean enabled # Whether key repeat is enabled.
 function love.keyboard.hasKeyRepeat() end
 
 ---
 ---Gets whether screen keyboard is supported.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.keyboard.hasScreenKeyboard)
 ---
 ---@return boolean supported # Whether screen keyboard is supported.
 function love.keyboard.hasScreenKeyboard() end
@@ -43,11 +58,17 @@ function love.keyboard.hasScreenKeyboard() end
 ---
 ---Gets whether text input events are enabled.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.keyboard.hasTextInput)
+---
 ---@return boolean enabled # Whether text input events are enabled.
 function love.keyboard.hasTextInput() end
 
 ---
 ---Checks whether a certain key is down. Not to be confused with love.keypressed or love.keyreleased.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.keyboard.isDown)
 ---
 ---@overload fun(key: love.KeyConstant, ...):boolean
 ---@param key love.KeyConstant # The key to check.
@@ -59,6 +80,9 @@ function love.keyboard.isDown(key) end
 ---
 ---Unlike regular KeyConstants, Scancodes are keyboard layout-independent. The scancode 'w' is used if the key in the same place as the 'w' key on an American keyboard is pressed, no matter what the key is labelled or what the user's operating system settings are.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.keyboard.isScancodeDown)
+---
 ---@param scancode love.Scancode # A Scancode to check.
 ---@vararg love.Scancode # Additional Scancodes to check.
 ---@return boolean down # True if any supplied Scancode is down, false if not.
@@ -66,6 +90,9 @@ function love.keyboard.isScancodeDown(scancode, ...) end
 
 ---
 ---Enables or disables key repeat for love.keypressed. It is disabled by default.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.keyboard.setKeyRepeat)
 ---
 ---@param enable boolean # Whether repeat keypress events should be enabled when a key is held down.
 function love.keyboard.setKeyRepeat(enable) end
@@ -75,12 +102,18 @@ function love.keyboard.setKeyRepeat(enable) end
 ---
 ---On touch devices, this shows the system's native on-screen keyboard when it's enabled.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.keyboard.setTextInput)
+---
 ---@overload fun(enable: boolean, x: number, y: number, w: number, h: number)
 ---@param enable boolean # Whether text input events should be enabled.
 function love.keyboard.setTextInput(enable) end
 
 ---
 ---All the keys you can press. Note that some keys may not be available on your keyboard or system.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/KeyConstant)
 ---
 ---@alias love.KeyConstant
 ---
@@ -668,6 +701,9 @@ function love.keyboard.setTextInput(enable) end
 ---Using scancodes, rather than keycodes, is useful because keyboards with layouts differing from the US/UK layout(s) might have keys that generate 'unknown' keycodes, but the scancodes will still be detected. This however would necessitate having a list for each keyboard layout one would choose to support.
 ---
 ---One could use textinput or textedited instead, but those only give back the end result of keys used, i.e. you can't get modifiers on their own from it, only the final symbols that were generated.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Scancode)
 ---
 ---@alias love.Scancode
 ---

--- a/meta/3rd/love2d/library/love/math.lua
+++ b/meta/3rd/love2d/library/love/math.lua
@@ -3,11 +3,17 @@
 ---
 ---Provides system-independent mathematical functions.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math)
+---
 ---@class love.math
 love.math = {}
 
 ---
 ---Converts a color from 0..255 to 0..1 range.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.colorFromBytes)
 ---
 ---@param rb number # Red color component in 0..255 range.
 ---@param gb number # Green color component in 0..255 range.
@@ -22,6 +28,9 @@ function love.math.colorFromBytes(rb, gb, bb, ab) end
 ---
 ---Converts a color from 0..1 to 0..255 range.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.colorToBytes)
+---
 ---@param r number # Red color component.
 ---@param g number # Green color component.
 ---@param b number # Blue color component.
@@ -35,6 +44,9 @@ function love.math.colorToBytes(r, g, b, a) end
 ---
 ---Compresses a string or data using a specific compression algorithm.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.compress)
+---
 ---@overload fun(data: love.Data, format?: love.CompressedDataFormat, level?: number):love.CompressedData
 ---@param rawstring string # The raw (un-compressed) string to compress.
 ---@param format? love.CompressedDataFormat # The format to use when compressing the string.
@@ -44,6 +56,9 @@ function love.math.compress(rawstring, format, level) end
 
 ---
 ---Decompresses a CompressedData or previously compressed string or Data object.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.decompress)
 ---
 ---@overload fun(compressedstring: string, format: love.CompressedDataFormat):string
 ---@overload fun(data: love.Data, format: love.CompressedDataFormat):string
@@ -57,6 +72,9 @@ function love.math.decompress(compressedData) end
 ---Read more about gamma-correct rendering here, here, and here.
 ---
 ---In versions prior to 11.0, color component values were within the range of 0 to 255 instead of 0 to 1.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.gammaToLinear)
 ---
 ---@overload fun(color: table):number, number, number
 ---@overload fun(c: number):number
@@ -73,6 +91,9 @@ function love.math.gammaToLinear(r, g, b) end
 ---
 ---The seed is split into two numbers due to Lua's use of doubles for all number values - doubles can't accurately represent integer  values above 2^53, but the seed can be an integer value up to 2^64.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.getRandomSeed)
+---
 ---@return number low # Integer number representing the lower 32 bits of the random number generator's 64 bit seed value.
 ---@return number high # Integer number representing the higher 32 bits of the random number generator's 64 bit seed value.
 function love.math.getRandomSeed() end
@@ -82,6 +103,9 @@ function love.math.getRandomSeed() end
 ---
 ---This is different from love.math.getRandomSeed in that getRandomState gets the random number generator's current state, whereas getRandomSeed gets the previously set seed number.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.getRandomState)
+---
 ---@return string state # The current state of the random number generator, represented as a string.
 function love.math.getRandomState() end
 
@@ -89,6 +113,9 @@ function love.math.getRandomState() end
 ---Checks whether a polygon is convex.
 ---
 ---PolygonShapes in love.physics, some forms of Meshes, and polygons drawn with love.graphics.polygon must be simple convex polygons.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.isConvex)
 ---
 ---@overload fun(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number):boolean
 ---@param vertices table # The vertices of the polygon as a table in the form of {x1, y1, x2, y2, x3, y3, ...}.
@@ -103,6 +130,9 @@ function love.math.isConvex(vertices) end
 ---Read more about gamma-correct rendering here, here, and here.
 ---
 ---In versions prior to 11.0, color component values were within the range of 0 to 255 instead of 0 to 1.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.linearToGamma)
 ---
 ---@overload fun(color: table):number, number, number
 ---@overload fun(lc: number):number
@@ -119,6 +149,9 @@ function love.math.linearToGamma(lr, lg, lb) end
 ---
 ---The number of vertices in the control polygon determines the degree of the curve, e.g. three vertices define a quadratic (degree 2) Bézier curve, four vertices define a cubic (degree 3) Bézier curve, etc.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.newBezierCurve)
+---
 ---@overload fun(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number):love.BezierCurve
 ---@param vertices table # The vertices of the control polygon as a table in the form of {x1, y1, x2, y2, x3, y3, ...}.
 ---@return love.BezierCurve curve # A Bézier curve object.
@@ -127,6 +160,9 @@ function love.math.newBezierCurve(vertices) end
 ---
 ---Creates a new RandomGenerator object which is completely independent of other RandomGenerator objects and random functions.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.newRandomGenerator)
+---
 ---@overload fun(seed: number):love.RandomGenerator
 ---@overload fun(low: number, high: number):love.RandomGenerator
 ---@return love.RandomGenerator rng # The new Random Number Generator object.
@@ -134,6 +170,9 @@ function love.math.newRandomGenerator() end
 
 ---
 ---Creates a new Transform object.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.newTransform)
 ---
 ---@overload fun(x: number, y: number, angle?: number, sx?: number, sy?: number, ox?: number, oy?: number, kx?: number, ky?: number):love.Transform
 ---@return love.Transform transform # The new Transform object.
@@ -146,6 +185,9 @@ function love.math.newTransform() end
 ---
 ---There are many webpages which discuss Perlin and Simplex noise in detail.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.noise)
+---
 ---@overload fun(x: number, y: number):number
 ---@overload fun(x: number, y: number, z: number):number
 ---@overload fun(x: number, y: number, z: number, w: number):number
@@ -156,6 +198,9 @@ function love.math.noise(x) end
 ---
 ---Generates a pseudo-random number in a platform independent manner. The default love.run seeds this function at startup, so you generally don't need to seed it yourself.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.random)
+---
 ---@overload fun(max: number):number
 ---@overload fun(min: number, max: number):number
 ---@return number number # The pseudo-random number.
@@ -164,6 +209,9 @@ function love.math.random() end
 ---
 ---Get a normally distributed pseudo random number.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.randomNormal)
+---
 ---@param stddev? number # Standard deviation of the distribution.
 ---@param mean? number # The mean of the distribution.
 ---@return number number # Normally distributed random number with variance (stddev)² and the specified mean.
@@ -171,6 +219,9 @@ function love.math.randomNormal(stddev, mean) end
 
 ---
 ---Sets the seed of the random number generator using the specified integer number. This is called internally at startup, so you generally don't need to call it yourself.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.setRandomSeed)
 ---
 ---@overload fun(low: number, high: number)
 ---@param seed number # The integer number with which you want to seed the randomization. Must be within the range of 2^53 - 1.
@@ -181,11 +232,17 @@ function love.math.setRandomSeed(seed) end
 ---
 ---This is different from love.math.setRandomSeed in that setRandomState directly sets the random number generator's current implementation-dependent state, whereas setRandomSeed gives it a new seed value.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.setRandomState)
+---
 ---@param state string # The new state of the random number generator, represented as a string. This should originate from a previous call to love.math.getRandomState.
 function love.math.setRandomState(state) end
 
 ---
 ---Decomposes a simple convex or concave polygon into triangles.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math.triangulate)
 ---
 ---@overload fun(x1: number, y1: number, x2: number, y2: number, x3: number, y3: number):table
 ---@param polygon table # Polygon to triangulate. Must not intersect itself.
@@ -197,6 +254,9 @@ function love.math.triangulate(polygon) end
 ---
 ---For more information on Bézier curves check this great article on Wikipedia.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math)
+---
 ---@class love.BezierCurve: love.Object
 local BezierCurve = {}
 
@@ -204,6 +264,9 @@ local BezierCurve = {}
 ---Evaluate Bézier curve at parameter t. The parameter must be between 0 and 1 (inclusive).
 ---
 ---This function can be used to move objects along paths or tween parameters. However it should not be used to render the curve, see BezierCurve:render for that purpose.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/BezierCurve:evaluate)
 ---
 ---@param t number # Where to evaluate the curve.
 ---@return number x # x coordinate of the curve at parameter t.
@@ -213,6 +276,9 @@ function BezierCurve:evaluate(t) end
 ---
 ---Get coordinates of the i-th control point. Indices start with 1.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/BezierCurve:getControlPoint)
+---
 ---@param i number # Index of the control point.
 ---@return number x # Position of the control point along the x axis.
 ---@return number y # Position of the control point along the y axis.
@@ -221,11 +287,17 @@ function BezierCurve:getControlPoint(i) end
 ---
 ---Get the number of control points in the Bézier curve.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/BezierCurve:getControlPointCount)
+---
 ---@return number count # The number of control points.
 function BezierCurve:getControlPointCount() end
 
 ---
 ---Get degree of the Bézier curve. The degree is equal to number-of-control-points - 1.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/BezierCurve:getDegree)
 ---
 ---@return number degree # Degree of the Bézier curve.
 function BezierCurve:getDegree() end
@@ -235,11 +307,17 @@ function BezierCurve:getDegree() end
 ---
 ---This function can be used to rotate sprites moving along a curve in the direction of the movement and compute the direction perpendicular to the curve at some parameter t.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/BezierCurve:getDerivative)
+---
 ---@return love.BezierCurve derivative # The derivative curve.
 function BezierCurve:getDerivative() end
 
 ---
 ---Gets a BezierCurve that corresponds to the specified segment of this BezierCurve.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/BezierCurve:getSegment)
 ---
 ---@param startpoint number # The starting point along the curve. Must be between 0 and 1.
 ---@param endpoint number # The end of the segment. Must be between 0 and 1.
@@ -249,6 +327,9 @@ function BezierCurve:getSegment(startpoint, endpoint) end
 ---
 ---Insert control point as the new i-th control point. Existing control points from i onwards are pushed back by 1. Indices start with 1. Negative indices wrap around: -1 is the last control point, -2 the one before the last, etc.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/BezierCurve:insertControlPoint)
+---
 ---@param x number # Position of the control point along the x axis.
 ---@param y number # Position of the control point along the y axis.
 ---@param i? number # Index of the control point.
@@ -256,6 +337,9 @@ function BezierCurve:insertControlPoint(x, y, i) end
 
 ---
 ---Removes the specified control point.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/BezierCurve:removeControlPoint)
 ---
 ---@param index number # The index of the control point to remove.
 function BezierCurve:removeControlPoint(index) end
@@ -266,6 +350,9 @@ function BezierCurve:removeControlPoint(index) end
 ---This function samples the Bézier curve using recursive subdivision. You can control the recursion depth using the depth parameter.
 ---
 ---If you are just interested to know the position on the curve given a parameter, use BezierCurve:evaluate.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/BezierCurve:render)
 ---
 ---@param depth? number # Number of recursive subdivision steps.
 ---@return table coordinates # List of x,y-coordinate pairs of points on the curve.
@@ -278,6 +365,9 @@ function BezierCurve:render(depth) end
 ---
 ---If you are just need to know the position on the curve given a parameter, use BezierCurve:evaluate.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/BezierCurve:renderSegment)
+---
 ---@param startpoint number # The starting point along the curve. Must be between 0 and 1.
 ---@param endpoint number # The end of the segment to render. Must be between 0 and 1.
 ---@param depth? number # Number of recursive subdivision steps.
@@ -287,6 +377,9 @@ function BezierCurve:renderSegment(startpoint, endpoint, depth) end
 ---
 ---Rotate the Bézier curve by an angle.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/BezierCurve:rotate)
+---
 ---@param angle number # Rotation angle in radians.
 ---@param ox? number # X coordinate of the rotation center.
 ---@param oy? number # Y coordinate of the rotation center.
@@ -294,6 +387,9 @@ function BezierCurve:rotate(angle, ox, oy) end
 
 ---
 ---Scale the Bézier curve by a factor.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/BezierCurve:scale)
 ---
 ---@param s number # Scale factor.
 ---@param ox? number # X coordinate of the scaling center.
@@ -303,6 +399,9 @@ function BezierCurve:scale(s, ox, oy) end
 ---
 ---Set coordinates of the i-th control point. Indices start with 1.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/BezierCurve:setControlPoint)
+---
 ---@param i number # Index of the control point.
 ---@param x number # Position of the control point along the x axis.
 ---@param y number # Position of the control point along the y axis.
@@ -311,12 +410,18 @@ function BezierCurve:setControlPoint(i, x, y) end
 ---
 ---Move the Bézier curve by an offset.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/BezierCurve:translate)
+---
 ---@param dx number # Offset along the x axis.
 ---@param dy number # Offset along the y axis.
 function BezierCurve:translate(dx, dy) end
 
 ---
 ---A random number generation object which has its own random state.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math)
 ---
 ---@class love.RandomGenerator: love.Object
 local RandomGenerator = {}
@@ -325,6 +430,9 @@ local RandomGenerator = {}
 ---Gets the seed of the random number generator object.
 ---
 ---The seed is split into two numbers due to Lua's use of doubles for all number values - doubles can't accurately represent integer  values above 2^53, but the seed value is an integer number in the range of 2^64 - 1.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/RandomGenerator:getSeed)
 ---
 ---@return number low # Integer number representing the lower 32 bits of the RandomGenerator's 64 bit seed value.
 ---@return number high # Integer number representing the higher 32 bits of the RandomGenerator's 64 bit seed value.
@@ -335,11 +443,17 @@ function RandomGenerator:getSeed() end
 ---
 ---This is different from RandomGenerator:getSeed in that getState gets the RandomGenerator's current state, whereas getSeed gets the previously set seed number.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RandomGenerator:getState)
+---
 ---@return string state # The current state of the RandomGenerator object, represented as a string.
 function RandomGenerator:getState() end
 
 ---
 ---Generates a pseudo-random number in a platform independent manner.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/RandomGenerator:random)
 ---
 ---@overload fun(self: love.RandomGenerator, max: number):number
 ---@overload fun(self: love.RandomGenerator, min: number, max: number):number
@@ -349,6 +463,9 @@ function RandomGenerator:random() end
 ---
 ---Get a normally distributed pseudo random number.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RandomGenerator:randomNormal)
+---
 ---@param stddev? number # Standard deviation of the distribution.
 ---@param mean? number # The mean of the distribution.
 ---@return number number # Normally distributed random number with variance (stddev)² and the specified mean.
@@ -356,6 +473,9 @@ function RandomGenerator:randomNormal(stddev, mean) end
 
 ---
 ---Sets the seed of the random number generator using the specified integer number.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/RandomGenerator:setSeed)
 ---
 ---@overload fun(self: love.RandomGenerator, low: number, high: number)
 ---@param seed number # The integer number with which you want to seed the randomization. Must be within the range of 2^53.
@@ -366,6 +486,9 @@ function RandomGenerator:setSeed(seed) end
 ---
 ---This is different from RandomGenerator:setSeed in that setState directly sets the RandomGenerator's current implementation-dependent state, whereas setSeed gives it a new seed value.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RandomGenerator:setState)
+---
 ---@param state string # The new state of the RandomGenerator object, represented as a string. This should originate from a previous call to RandomGenerator:getState.
 function RandomGenerator:setState(state) end
 
@@ -373,6 +496,9 @@ function RandomGenerator:setState(state) end
 ---Object containing a coordinate system transformation.
 ---
 ---The love.graphics module has several functions and function variants which accept Transform objects.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.math)
 ---
 ---@class love.Transform: love.Object
 local Transform = {}
@@ -382,6 +508,9 @@ local Transform = {}
 ---
 ---This effectively multiplies this Transform's internal transformation matrix with the other Transform's (i.e. self * other), and stores the result in this object.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Transform:apply)
+---
 ---@param other love.Transform # The other Transform object to apply to this Transform.
 ---@return love.Transform transform # The Transform object the method was called on. Allows easily chaining Transform methods.
 function Transform:apply(other) end
@@ -389,11 +518,17 @@ function Transform:apply(other) end
 ---
 ---Creates a new copy of this Transform.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Transform:clone)
+---
 ---@return love.Transform clone # The copy of this Transform.
 function Transform:clone() end
 
 ---
 ---Gets the internal 4x4 transformation matrix stored by this Transform. The matrix is returned in row-major order.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Transform:getMatrix)
 ---
 ---@return number e1_1 # The first column of the first row of the matrix.
 ---@return number e1_2 # The second column of the first row of the matrix.
@@ -402,6 +537,9 @@ function Transform:getMatrix() end
 
 ---
 ---Creates a new Transform containing the inverse of this Transform.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Transform:inverse)
 ---
 ---@return love.Transform inverse # A new Transform object representing the inverse of this Transform's matrix.
 function Transform:inverse() end
@@ -413,6 +551,9 @@ function Transform:inverse() end
 ---
 ---One use of this method can be to convert a screen-space mouse position into global world coordinates, if the given Transform has transformations applied that are used for a camera system in-game.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Transform:inverseTransformPoint)
+---
 ---@param localX number # The x component of the position with the transform applied.
 ---@param localY number # The y component of the position with the transform applied.
 ---@return number globalX # The x component of the position in global coordinates.
@@ -422,17 +563,26 @@ function Transform:inverseTransformPoint(localX, localY) end
 ---
 ---Checks whether the Transform is an affine transformation.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Transform:isAffine2DTransform)
+---
 ---@return boolean affine # true if the transform object is an affine transformation, false otherwise.
 function Transform:isAffine2DTransform() end
 
 ---
 ---Resets the Transform to an identity state. All previously applied transformations are erased.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Transform:reset)
+---
 ---@return love.Transform transform # The Transform object the method was called on. Allows easily chaining Transform methods.
 function Transform:reset() end
 
 ---
 ---Applies a rotation to the Transform's coordinate system. This method does not reset any previously applied transformations.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Transform:rotate)
 ---
 ---@param angle number # The relative angle in radians to rotate this Transform by.
 ---@return love.Transform transform # The Transform object the method was called on. Allows easily chaining Transform methods.
@@ -441,6 +591,9 @@ function Transform:rotate(angle) end
 ---
 ---Scales the Transform's coordinate system. This method does not reset any previously applied transformations.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Transform:scale)
+---
 ---@param sx number # The relative scale factor along the x-axis.
 ---@param sy? number # The relative scale factor along the y-axis.
 ---@return love.Transform transform # The Transform object the method was called on. Allows easily chaining Transform methods.
@@ -448,6 +601,9 @@ function Transform:scale(sx, sy) end
 
 ---
 ---Directly sets the Transform's internal 4x4 transformation matrix.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Transform:setMatrix)
 ---
 ---@overload fun(self: love.Transform, layout: love.MatrixLayout, e1_1: number, e1_2: number, ..., e4_4: number):love.Transform
 ---@overload fun(self: love.Transform, layout: love.MatrixLayout, matrix: table):love.Transform
@@ -461,6 +617,9 @@ function Transform:setMatrix(e1_1, e1_2, ..., e4_4) end
 
 ---
 ---Resets the Transform to the specified transformation parameters.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Transform:setTransformation)
 ---
 ---@param x number # The position of the Transform on the x-axis.
 ---@param y number # The position of the Transform on the y-axis.
@@ -477,6 +636,9 @@ function Transform:setTransformation(x, y, angle, sx, sy, ox, oy, kx, ky) end
 ---
 ---Applies a shear factor (skew) to the Transform's coordinate system. This method does not reset any previously applied transformations.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Transform:shear)
+---
 ---@param kx number # The shear factor along the x-axis.
 ---@param ky number # The shear factor along the y-axis.
 ---@return love.Transform transform # The Transform object the method was called on. Allows easily chaining Transform methods.
@@ -487,6 +649,9 @@ function Transform:shear(kx, ky) end
 ---
 ---This effectively converts the given position from global coordinates into the local coordinate space of the Transform.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Transform:transformPoint)
+---
 ---@param globalX number # The x component of the position in global coordinates.
 ---@param globalY number # The y component of the position in global coordinates.
 ---@return number localX # The x component of the position with the transform applied.
@@ -496,6 +661,9 @@ function Transform:transformPoint(globalX, globalY) end
 ---
 ---Applies a translation to the Transform's coordinate system. This method does not reset any previously applied transformations.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Transform:translate)
+---
 ---@param dx number # The relative translation along the x-axis.
 ---@param dy number # The relative translation along the y-axis.
 ---@return love.Transform transform # The Transform object the method was called on. Allows easily chaining Transform methods.
@@ -503,6 +671,9 @@ function Transform:translate(dx, dy) end
 
 ---
 ---The layout of matrix elements (row-major or column-major).
+---
+---
+---[Open in Browser](https://love2d.org/wiki/MatrixLayout)
 ---
 ---@alias love.MatrixLayout
 ---

--- a/meta/3rd/love2d/library/love/mouse.lua
+++ b/meta/3rd/love2d/library/love/mouse.lua
@@ -3,17 +3,26 @@
 ---
 ---Provides an interface to the user's mouse.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse)
+---
 ---@class love.mouse
 love.mouse = {}
 
 ---
 ---Gets the current Cursor.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.getCursor)
+---
 ---@return love.Cursor cursor # The current cursor, or nil if no cursor is set.
 function love.mouse.getCursor() end
 
 ---
 ---Returns the current position of the mouse.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.getPosition)
 ---
 ---@return number x # The position of the mouse along the x-axis.
 ---@return number y # The position of the mouse along the y-axis.
@@ -26,6 +35,9 @@ function love.mouse.getPosition() end
 ---
 ---The reported position of the mouse is not updated while relative mode is enabled, even when relative mouse motion events are generated.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.getRelativeMode)
+---
 ---@return boolean enabled # True if relative mode is enabled, false if it's disabled.
 function love.mouse.getRelativeMode() end
 
@@ -34,6 +46,9 @@ function love.mouse.getRelativeMode() end
 ---
 ---Hardware cursors are framerate-independent and work the same way as normal operating system cursors. Unlike drawing an image at the mouse's current coordinates, hardware cursors never have visible lag between when the mouse is moved and when the cursor position updates, even at low framerates.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.getSystemCursor)
+---
 ---@param ctype love.CursorType # The type of system cursor to get. 
 ---@return love.Cursor cursor # The Cursor object representing the system cursor type.
 function love.mouse.getSystemCursor(ctype) end
@@ -41,11 +56,17 @@ function love.mouse.getSystemCursor(ctype) end
 ---
 ---Returns the current x-position of the mouse.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.getX)
+---
 ---@return number x # The position of the mouse along the x-axis.
 function love.mouse.getX() end
 
 ---
 ---Returns the current y-position of the mouse.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.getY)
 ---
 ---@return number y # The position of the mouse along the y-axis.
 function love.mouse.getY() end
@@ -55,6 +76,9 @@ function love.mouse.getY() end
 ---
 ---If it isn't supported, calling love.mouse.newCursor and love.mouse.getSystemCursor will cause an error. Mobile devices do not support cursors.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.isCursorSupported)
+---
 ---@return boolean supported # Whether the system has cursor functionality.
 function love.mouse.isCursorSupported() end
 
@@ -62,6 +86,9 @@ function love.mouse.isCursorSupported() end
 ---Checks whether a certain mouse button is down.
 ---
 ---This function does not detect mouse wheel scrolling; you must use the love.wheelmoved (or love.mousepressed in version 0.9.2 and older) callback for that. 
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.isDown)
 ---
 ---@param button number # The index of a button to check. 1 is the primary mouse button, 2 is the secondary mouse button and 3 is the middle button. Further buttons are mouse dependant.
 ---@vararg number # Additional button numbers to check.
@@ -71,11 +98,17 @@ function love.mouse.isDown(button, ...) end
 ---
 ---Checks if the mouse is grabbed.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.isGrabbed)
+---
 ---@return boolean grabbed # True if the cursor is grabbed, false if it is not.
 function love.mouse.isGrabbed() end
 
 ---
 ---Checks if the cursor is visible.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.isVisible)
 ---
 ---@return boolean visible # True if the cursor to visible, false if the cursor is hidden.
 function love.mouse.isVisible() end
@@ -86,6 +119,9 @@ function love.mouse.isVisible() end
 ---Hardware cursors are framerate-independent and work the same way as normal operating system cursors. Unlike drawing an image at the mouse's current coordinates, hardware cursors never have visible lag between when the mouse is moved and when the cursor position updates, even at low framerates.
 ---
 ---The hot spot is the point the operating system uses to determine what was clicked and at what position the mouse cursor is. For example, the normal arrow pointer normally has its hot spot at the top left of the image, but a crosshair cursor might have it in the middle.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.newCursor)
 ---
 ---@overload fun(filename: string, hotx?: number, hoty?: number):love.Cursor
 ---@overload fun(fileData: love.FileData, hotx?: number, hoty?: number):love.Cursor
@@ -98,6 +134,9 @@ function love.mouse.newCursor(imageData, hotx, hoty) end
 ---
 ---Sets the current mouse cursor.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.setCursor)
+---
 ---@overload fun()
 ---@param cursor love.Cursor # The Cursor object to use as the current mouse cursor.
 function love.mouse.setCursor(cursor) end
@@ -105,11 +144,17 @@ function love.mouse.setCursor(cursor) end
 ---
 ---Grabs the mouse and confines it to the window.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.setGrabbed)
+---
 ---@param grab boolean # True to confine the mouse, false to let it leave the window.
 function love.mouse.setGrabbed(grab) end
 
 ---
 ---Sets the current position of the mouse. Non-integer values are floored.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.setPosition)
 ---
 ---@param x number # The new position of the mouse along the x-axis.
 ---@param y number # The new position of the mouse along the y-axis.
@@ -122,11 +167,17 @@ function love.mouse.setPosition(x, y) end
 ---
 ---The reported position of the mouse may not be updated while relative mode is enabled, even when relative mouse motion events are generated.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.setRelativeMode)
+---
 ---@param enable boolean # True to enable relative mode, false to disable it.
 function love.mouse.setRelativeMode(enable) end
 
 ---
 ---Sets the current visibility of the cursor.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.setVisible)
 ---
 ---@param visible boolean # True to set the cursor to visible, false to hide the cursor.
 function love.mouse.setVisible(visible) end
@@ -136,6 +187,9 @@ function love.mouse.setVisible(visible) end
 ---
 ---Non-integer values are floored.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.setX)
+---
 ---@param x number # The new position of the mouse along the x-axis.
 function love.mouse.setX(x) end
 
@@ -144,11 +198,17 @@ function love.mouse.setX(x) end
 ---
 ---Non-integer values are floored.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse.setY)
+---
 ---@param y number # The new position of the mouse along the y-axis.
 function love.mouse.setY(y) end
 
 ---
 ---Represents a hardware cursor.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.mouse)
 ---
 ---@class love.Cursor: love.Object
 local Cursor = {}
@@ -156,11 +216,17 @@ local Cursor = {}
 ---
 ---Gets the type of the Cursor.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Cursor:getType)
+---
 ---@return love.CursorType ctype # The type of the Cursor.
 function Cursor:getType() end
 
 ---
 ---Types of hardware cursors.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/CursorType)
 ---
 ---@alias love.CursorType
 ---

--- a/meta/3rd/love2d/library/love/physics.lua
+++ b/meta/3rd/love2d/library/love/physics.lua
@@ -3,11 +3,17 @@
 ---
 ---Can simulate 2D rigid body physics in a realistic manner. This module is based on Box2D, and this API corresponds to the Box2D API as closely as possible.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
+---
 ---@class love.physics
 love.physics = {}
 
 ---
 ---Returns the two closest points between two fixtures and their distance.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.getDistance)
 ---
 ---@param fixture1 love.Fixture # The first fixture.
 ---@param fixture2 love.Fixture # The second fixture.
@@ -25,6 +31,9 @@ function love.physics.getDistance(fixture1, fixture2) end
 ---
 ---It is recommended to create shapes no larger than 10 times the scale. This is important because Box2D is tuned to work well with shape sizes from 0.1 to 10 meters.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.getMeter)
+---
 ---@return number scale # The scale factor as an integer.
 function love.physics.getMeter() end
 
@@ -41,6 +50,9 @@ function love.physics.getMeter() end
 ---
 ---The mass of the body gets calculated when a Fixture is attached or removed, but can be changed at any time with Body:setMass or Body:resetMassData.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newBody)
+---
 ---@param world love.World # The world to create the body in.
 ---@param x? number # The x position of the body.
 ---@param y? number # The y position of the body.
@@ -50,6 +62,9 @@ function love.physics.newBody(world, x, y, type) end
 
 ---
 ---Creates a new ChainShape.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newChainShape)
 ---
 ---@overload fun(loop: boolean, points: table):love.ChainShape
 ---@param loop boolean # If the chain should loop back to the first point.
@@ -64,6 +79,9 @@ function love.physics.newChainShape(loop, x1, y1, x2, y2, ...) end
 ---
 ---Creates a new CircleShape.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newCircleShape)
+---
 ---@overload fun(x: number, y: number, radius: number):love.CircleShape
 ---@param radius number # The radius of the circle.
 ---@return love.CircleShape shape # The new shape.
@@ -73,6 +91,9 @@ function love.physics.newCircleShape(radius) end
 ---Creates a DistanceJoint between two bodies.
 ---
 ---This joint constrains the distance between two points on two bodies to be constant. These two points are specified in world coordinates and the two bodies are assumed to be in place when this joint is created. The first anchor point is connected to the first body and the second to the second body, and the points define the length of the distance joint.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newDistanceJoint)
 ---
 ---@param body1 love.Body # The first body to attach to the joint.
 ---@param body2 love.Body # The second body to attach to the joint.
@@ -87,6 +108,9 @@ function love.physics.newDistanceJoint(body1, body2, x1, y1, x2, y2, collideConn
 ---
 ---Creates a new EdgeShape.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newEdgeShape)
+---
 ---@param x1 number # The x position of the first point.
 ---@param y1 number # The y position of the first point.
 ---@param x2 number # The x position of the second point.
@@ -99,6 +123,9 @@ function love.physics.newEdgeShape(x1, y1, x2, y2) end
 ---
 ---Note that the Shape object is copied rather than kept as a reference when the Fixture is created. To get the Shape object that the Fixture owns, use Fixture:getShape.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newFixture)
+---
 ---@param body love.Body # The body which gets the fixture attached.
 ---@param shape love.Shape # The shape to be copied to the fixture.
 ---@param density? number # The density of the fixture.
@@ -107,6 +134,9 @@ function love.physics.newFixture(body, shape, density) end
 
 ---
 ---Create a friction joint between two bodies. A FrictionJoint applies friction to a body.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newFrictionJoint)
 ---
 ---@overload fun(body1: love.Body, body2: love.Body, x1: number, y1: number, x2: number, y2: number, collideConnected?: boolean):love.FrictionJoint
 ---@param body1 love.Body # The first body to attach to the joint.
@@ -124,6 +154,9 @@ function love.physics.newFrictionJoint(body1, body2, x, y, collideConnected) end
 ---
 ---The gear joint has a ratio the determines how the angular or distance values of the connected joints relate to each other. The formula coordinate1 + ratio * coordinate2 always has a constant value that is set when the gear joint is created.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newGearJoint)
+---
 ---@param joint1 love.Joint # The first joint to connect with a gear joint.
 ---@param joint2 love.Joint # The second joint to connect with a gear joint.
 ---@param ratio? number # The gear ratio.
@@ -135,6 +168,9 @@ function love.physics.newGearJoint(joint1, joint2, ratio, collideConnected) end
 ---Creates a joint between two bodies which controls the relative motion between them.
 ---
 ---Position and rotation offsets can be specified once the MotorJoint has been created, as well as the maximum motor force and torque that will be be applied to reach the target offsets.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newMotorJoint)
 ---
 ---@overload fun(body1: love.Body, body2: love.Body, correctionFactor?: number, collideConnected?: boolean):love.MotorJoint
 ---@param body1 love.Body # The first body to attach to the joint.
@@ -150,6 +186,9 @@ function love.physics.newMotorJoint(body1, body2, correctionFactor) end
 ---
 ---The advantage of using a MouseJoint instead of just changing a body position directly is that collisions and reactions to other joints are handled by the physics engine. 
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newMouseJoint)
+---
 ---@param body love.Body # The body to attach to the mouse.
 ---@param x number # The x position of the connecting point.
 ---@param y number # The y position of the connecting point.
@@ -160,6 +199,9 @@ function love.physics.newMouseJoint(body, x, y) end
 ---Creates a new PolygonShape.
 ---
 ---This shape can have 8 vertices at most, and must form a convex shape.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newPolygonShape)
 ---
 ---@overload fun(vertices: table):love.PolygonShape
 ---@param x1 number # The x position of the first point.
@@ -176,6 +218,9 @@ function love.physics.newPolygonShape(x1, y1, x2, y2, x3, y3, ...) end
 ---Creates a PrismaticJoint between two bodies.
 ---
 ---A prismatic joint constrains two bodies to move relatively to each other on a specified axis. It does not allow for relative rotation. Its definition and operation are similar to a  revolute joint, but with translation and force substituted for angle and torque.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newPrismaticJoint)
 ---
 ---@overload fun(body1: love.Body, body2: love.Body, x1: number, y1: number, x2: number, y2: number, ax: number, ay: number, collideConnected?: boolean):love.PrismaticJoint
 ---@overload fun(body1: love.Body, body2: love.Body, x1: number, y1: number, x2: number, y2: number, ax: number, ay: number, collideConnected?: boolean, referenceAngle?: number):love.PrismaticJoint
@@ -195,6 +240,9 @@ function love.physics.newPrismaticJoint(body1, body2, x, y, ax, ay, collideConne
 ---The pulley joint simulates a pulley with an optional block and tackle. If the ratio parameter has a value different from one, then the simulated rope extends faster on one side than the other. In a pulley joint the total length of the simulated rope is the constant length1 + ratio * length2, which is set when the pulley joint is created.
 ---
 ---Pulley joints can behave unpredictably if one side is fully extended. It is recommended that the method  setMaxLengths  be used to constrain the maximum lengths each side can attain.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newPulleyJoint)
 ---
 ---@param body1 love.Body # The first body to connect with a pulley joint.
 ---@param body2 love.Body # The second body to connect with a pulley joint.
@@ -216,6 +264,9 @@ function love.physics.newPulleyJoint(body1, body2, gx1, gy1, gx2, gy2, x1, y1, x
 ---
 ---By default, the local origin is located at the '''center''' of the rectangle as opposed to the top left for graphics.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newRectangleShape)
+---
 ---@overload fun(x: number, y: number, width: number, height: number, angle?: number):love.PolygonShape
 ---@param width number # The width of the rectangle.
 ---@param height number # The height of the rectangle.
@@ -226,6 +277,9 @@ function love.physics.newRectangleShape(width, height) end
 ---Creates a pivot joint between two bodies.
 ---
 ---This joint connects two bodies to a point around which they can pivot.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newRevoluteJoint)
 ---
 ---@overload fun(body1: love.Body, body2: love.Body, x1: number, y1: number, x2: number, y2: number, collideConnected?: boolean, referenceAngle?: number):love.RevoluteJoint
 ---@param body1 love.Body # The first body.
@@ -238,6 +292,9 @@ function love.physics.newRevoluteJoint(body1, body2, x, y, collideConnected) end
 
 ---
 ---Creates a joint between two bodies. Its only function is enforcing a max distance between these bodies.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newRopeJoint)
 ---
 ---@param body1 love.Body # The first body to attach to the joint.
 ---@param body2 love.Body # The second body to attach to the joint.
@@ -253,6 +310,9 @@ function love.physics.newRopeJoint(body1, body2, x1, y1, x2, y2, maxLength, coll
 ---
 ---Creates a constraint joint between two bodies. A WeldJoint essentially glues two bodies together. The constraint is a bit soft, however, due to Box2D's iterative solver.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newWeldJoint)
+---
 ---@overload fun(body1: love.Body, body2: love.Body, x1: number, y1: number, x2: number, y2: number, collideConnected?: boolean):love.WeldJoint
 ---@overload fun(body1: love.Body, body2: love.Body, x1: number, y1: number, x2: number, y2: number, collideConnected?: boolean, referenceAngle?: number):love.WeldJoint
 ---@param body1 love.Body # The first body to attach to the joint.
@@ -265,6 +325,9 @@ function love.physics.newWeldJoint(body1, body2, x, y, collideConnected) end
 
 ---
 ---Creates a wheel joint.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newWheelJoint)
 ---
 ---@overload fun(body1: love.Body, body2: love.Body, x1: number, y1: number, x2: number, y2: number, ax: number, ay: number, collideConnected?: boolean):love.WheelJoint
 ---@param body1 love.Body # The first body.
@@ -280,6 +343,9 @@ function love.physics.newWheelJoint(body1, body2, x, y, ax, ay, collideConnected
 ---
 ---Creates a new World.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.newWorld)
+---
 ---@param xg? number # The x component of gravity.
 ---@param yg? number # The y component of gravity.
 ---@param sleep? boolean # Whether the bodies in this world are allowed to sleep.
@@ -293,11 +359,17 @@ function love.physics.newWorld(xg, yg, sleep) end
 ---
 ---It is recommended to create shapes no larger than 10 times the scale. This is important because Box2D is tuned to work well with shape sizes from 0.1 to 10 meters. The default meter scale is 30.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics.setMeter)
+---
 ---@param scale number # The scale factor as an integer.
 function love.physics.setMeter(scale) end
 
 ---
 ---Bodies are objects with velocity and position.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
 ---
 ---@class love.Body: love.Object
 local Body = {}
@@ -306,6 +378,9 @@ local Body = {}
 ---Applies an angular impulse to a body. This makes a single, instantaneous addition to the body momentum.
 ---
 ---A body with with a larger mass will react less. The reaction does '''not''' depend on the timestep, and is equivalent to applying a force continuously for 1 second. Impulses are best used to give a single push to a body. For a continuous push to a body it is better to use Body:applyForce.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:applyAngularImpulse)
 ---
 ---@param impulse number # The impulse in kilogram-square meter per second.
 function Body:applyAngularImpulse(impulse) end
@@ -318,6 +393,9 @@ function Body:applyAngularImpulse(impulse) end
 ---If the position to apply the force is not given, it will act on the center of mass of the body. The part of the force not directed towards the center of mass will cause the body to spin (and depends on the rotational inertia).
 ---
 ---Note that the force components and position must be given in world coordinates.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:applyForce)
 ---
 ---@overload fun(self: love.Body, fx: number, fy: number, x: number, y: number)
 ---@param fx number # The x component of force to apply to the center of mass.
@@ -335,6 +413,9 @@ function Body:applyForce(fx, fy) end
 ---
 ---Note that the impulse components and position must be given in world coordinates.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:applyLinearImpulse)
+---
 ---@overload fun(self: love.Body, ix: number, iy: number, x: number, y: number)
 ---@param ix number # The x component of the impulse applied to the center of mass.
 ---@param iy number # The y component of the impulse applied to the center of mass.
@@ -345,6 +426,9 @@ function Body:applyLinearImpulse(ix, iy) end
 ---
 ---Torque is like a force that will change the angular velocity (spin) of a body. The effect will depend on the rotational inertia a body has.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:applyTorque)
+---
 ---@param torque number # The torque to apply.
 function Body:applyTorque(torque) end
 
@@ -352,6 +436,9 @@ function Body:applyTorque(torque) end
 ---Explicitly destroys the Body and all fixtures and joints attached to it.
 ---
 ---An error will occur if you attempt to use the object after calling this function. In 0.7.2, when you don't have time to wait for garbage collection, this function may be used to free the object immediately.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:destroy)
 ---
 function Body:destroy() end
 
@@ -361,6 +448,9 @@ function Body:destroy() end
 ---The angle is measured in radians. If you need to transform it to degrees, use math.deg.
 ---
 ---A value of 0 radians will mean 'looking to the right'. Although radians increase counter-clockwise, the y axis points down so it becomes ''clockwise'' from our point of view.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getAngle)
 ---
 ---@return number angle # The angle in radians.
 function Body:getAngle() end
@@ -374,6 +464,9 @@ function Body:getAngle() end
 ---
 ---Damping parameters should be between 0 and infinity, with 0 meaning no damping, and infinity meaning full damping. Normally you will use a damping value between 0 and 0.1.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getAngularDamping)
+---
 ---@return number damping # The value of the angular damping.
 function Body:getAngularDamping() end
 
@@ -386,11 +479,17 @@ function Body:getAngularDamping() end
 ---
 ---If you need the ''rate of change of position over time'', use Body:getLinearVelocity.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getAngularVelocity)
+---
 ---@return number w # The angular velocity in radians/second.
 function Body:getAngularVelocity() end
 
 ---
 ---Gets a list of all Contacts attached to the Body.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getContacts)
 ---
 ---@return table contacts # A list with all contacts associated with the Body.
 function Body:getContacts() end
@@ -398,11 +497,17 @@ function Body:getContacts() end
 ---
 ---Returns a table with all fixtures.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getFixtures)
+---
 ---@return table fixtures # A sequence with all fixtures.
 function Body:getFixtures() end
 
 ---
 ---Returns the gravity scale factor.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getGravityScale)
 ---
 ---@return number scale # The gravity scale factor.
 function Body:getGravityScale() end
@@ -412,11 +517,17 @@ function Body:getGravityScale() end
 ---
 ---The rotational inertia is how hard is it to make the body spin.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getInertia)
+---
 ---@return number inertia # The rotational inertial of the body.
 function Body:getInertia() end
 
 ---
 ---Returns a table containing the Joints attached to this Body.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getJoints)
 ---
 ---@return table joints # A sequence with the Joints attached to the Body.
 function Body:getJoints() end
@@ -427,6 +538,9 @@ function Body:getJoints() end
 ---The linear damping is the ''rate of decrease of the linear velocity over time''. A moving body with no damping and no external forces will continue moving indefinitely, as is the case in space. A moving body with damping will gradually stop moving.
 ---
 ---Damping is not the same as friction - they can be modelled together.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getLinearDamping)
 ---
 ---@return number damping # The value of the linear damping.
 function Body:getLinearDamping() end
@@ -446,6 +560,9 @@ function Body:getLinearDamping() end
 ---
 ---See page 136 of 'Essential Mathematics for Games and Interactive Applications' for definitions of local and world coordinates.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getLinearVelocity)
+---
 ---@return number x # The x-component of the velocity vector
 ---@return number y # The y-component of the velocity vector
 function Body:getLinearVelocity() end
@@ -456,6 +573,9 @@ function Body:getLinearVelocity() end
 ---The linear velocity for a point on the body is the velocity of the body center of mass plus the velocity at that point from the body spinning.
 ---
 ---The point on the body must given in local coordinates. Use Body:getLinearVelocityFromWorldPoint to specify this with world coordinates.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getLinearVelocityFromLocalPoint)
 ---
 ---@param x number # The x position to measure velocity.
 ---@param y number # The y position to measure velocity.
@@ -470,6 +590,9 @@ function Body:getLinearVelocityFromLocalPoint(x, y) end
 ---
 ---The point on the body must given in world coordinates. Use Body:getLinearVelocityFromLocalPoint to specify this with local coordinates.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getLinearVelocityFromWorldPoint)
+---
 ---@param x number # The x position to measure velocity.
 ---@param y number # The y position to measure velocity.
 ---@return number vx # The x component of velocity at point (x,y).
@@ -481,12 +604,18 @@ function Body:getLinearVelocityFromWorldPoint(x, y) end
 ---
 ---Use Body:getWorldCenter to get the center of mass in world coordinates.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getLocalCenter)
+---
 ---@return number x # The x coordinate of the center of mass.
 ---@return number y # The y coordinate of the center of mass.
 function Body:getLocalCenter() end
 
 ---
 ---Transform a point from world coordinates to local coordinates.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getLocalPoint)
 ---
 ---@param worldX number # The x position in world coordinates.
 ---@param worldY number # The y position in world coordinates.
@@ -496,6 +625,9 @@ function Body:getLocalPoint(worldX, worldY) end
 
 ---
 ---Transforms multiple points from world coordinates to local coordinates.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getLocalPoints)
 ---
 ---@param x1 number # (Argument) The x position of the first point.
 ---@param y1 number # (Argument) The y position of the first point.
@@ -511,6 +643,9 @@ function Body:getLocalPoints(x1, y1, x2, y2, ...) end
 ---
 ---Transform a vector from world coordinates to local coordinates.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getLocalVector)
+---
 ---@param worldX number # The vector x component in world coordinates.
 ---@param worldY number # The vector y component in world coordinates.
 ---@return number localX # The vector x component in local coordinates.
@@ -522,11 +657,17 @@ function Body:getLocalVector(worldX, worldY) end
 ---
 ---Static bodies always have a mass of 0.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getMass)
+---
 ---@return number mass # The mass of the body (in kilograms).
 function Body:getMass() end
 
 ---
 ---Returns the mass, its center, and the rotational inertia.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getMassData)
 ---
 ---@return number x # The x position of the center of mass.
 ---@return number y # The y position of the center of mass.
@@ -539,6 +680,9 @@ function Body:getMassData() end
 ---
 ---Note that this may not be the center of mass of the body.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getPosition)
+---
 ---@return number x # The x position.
 ---@return number y # The y position.
 function Body:getPosition() end
@@ -548,6 +692,9 @@ function Body:getPosition() end
 ---
 ---Note that the position may not be the center of mass of the body. An angle of 0 radians will mean 'looking to the right'. Although radians increase counter-clockwise, the y axis points down so it becomes clockwise from our point of view.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getTransform)
+---
 ---@return number x # The x component of the position.
 ---@return number y # The y component of the position.
 ---@return number angle # The angle in radians.
@@ -556,17 +703,26 @@ function Body:getTransform() end
 ---
 ---Returns the type of the body.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getType)
+---
 ---@return love.BodyType type # The body type.
 function Body:getType() end
 
 ---
 ---Returns the Lua value associated with this Body.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getUserData)
+---
 ---@return any value # The Lua value associated with the Body.
 function Body:getUserData() end
 
 ---
 ---Gets the World the body lives in.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getWorld)
 ---
 ---@return love.World world # The world the body lives in.
 function Body:getWorld() end
@@ -576,12 +732,18 @@ function Body:getWorld() end
 ---
 ---Use Body:getLocalCenter to get the center of mass in local coordinates.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getWorldCenter)
+---
 ---@return number x # The x coordinate of the center of mass.
 ---@return number y # The y coordinate of the center of mass.
 function Body:getWorldCenter() end
 
 ---
 ---Transform a point from local coordinates to world coordinates.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getWorldPoint)
 ---
 ---@param localX number # The x position in local coordinates.
 ---@param localY number # The y position in local coordinates.
@@ -591,6 +753,9 @@ function Body:getWorldPoint(localX, localY) end
 
 ---
 ---Transforms multiple points from local coordinates to world coordinates.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getWorldPoints)
 ---
 ---@param x1 number # The x position of the first point.
 ---@param y1 number # The y position of the first point.
@@ -605,6 +770,9 @@ function Body:getWorldPoints(x1, y1, x2, y2) end
 ---
 ---Transform a vector from local coordinates to world coordinates.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getWorldVector)
+---
 ---@param localX number # The vector x component in local coordinates.
 ---@param localY number # The vector y component in local coordinates.
 ---@return number worldX # The vector x component in world coordinates.
@@ -614,11 +782,17 @@ function Body:getWorldVector(localX, localY) end
 ---
 ---Get the x position of the body in world coordinates.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getX)
+---
 ---@return number x # The x position in world coordinates.
 function Body:getX() end
 
 ---
 ---Get the y position of the body in world coordinates.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:getY)
 ---
 ---@return number y # The y position in world coordinates.
 function Body:getY() end
@@ -626,11 +800,17 @@ function Body:getY() end
 ---
 ---Returns whether the body is actively used in the simulation.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:isActive)
+---
 ---@return boolean status # True if the body is active or false if not.
 function Body:isActive() end
 
 ---
 ---Returns the sleep status of the body.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:isAwake)
 ---
 ---@return boolean status # True if the body is awake or false if not.
 function Body:isAwake() end
@@ -648,11 +828,17 @@ function Body:isAwake() end
 ---
 ---Note that static bodies (with zero mass) always use CCD, so your walls will not let a fast moving body pass through even if it is not a bullet.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:isBullet)
+---
 ---@return boolean status # The bullet status of the body.
 function Body:isBullet() end
 
 ---
 ---Gets whether the Body is destroyed. Destroyed bodies cannot be used.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:isDestroyed)
 ---
 ---@return boolean destroyed # Whether the Body is destroyed.
 function Body:isDestroyed() end
@@ -660,17 +846,26 @@ function Body:isDestroyed() end
 ---
 ---Returns whether the body rotation is locked.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:isFixedRotation)
+---
 ---@return boolean fixed # True if the body's rotation is locked or false if not.
 function Body:isFixedRotation() end
 
 ---
 ---Returns the sleeping behaviour of the body.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:isSleepingAllowed)
+---
 ---@return boolean allowed # True if the body is allowed to sleep or false if not.
 function Body:isSleepingAllowed() end
 
 ---
 ---Gets whether the Body is touching the given other Body.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:isTouching)
 ---
 ---@param otherbody love.Body # The other body to check.
 ---@return boolean touching # True if this body is touching the other body, false otherwise.
@@ -679,12 +874,18 @@ function Body:isTouching(otherbody) end
 ---
 ---Resets the mass of the body by recalculating it from the mass properties of the fixtures.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:resetMassData)
+---
 function Body:resetMassData() end
 
 ---
 ---Sets whether the body is active in the world.
 ---
 ---An inactive body does not take part in the simulation. It will not move or cause any collisions.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setActive)
 ---
 ---@param active boolean # If the body is active or not.
 function Body:setActive(active) end
@@ -698,6 +899,9 @@ function Body:setActive(active) end
 ---
 ---It is possible to cause a collision with another body by changing its angle. 
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setAngle)
+---
 ---@param angle number # The angle in radians.
 function Body:setAngle(angle) end
 
@@ -707,6 +911,9 @@ function Body:setAngle(angle) end
 ---See Body:getAngularDamping for a definition of angular damping.
 ---
 ---Angular damping can take any value from 0 to infinity. It is recommended to stay between 0 and 0.1, though. Other values will look unrealistic.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setAngularDamping)
 ---
 ---@param damping number # The new angular damping.
 function Body:setAngularDamping(damping) end
@@ -718,11 +925,17 @@ function Body:setAngularDamping(damping) end
 ---
 ---This function will not accumulate anything; any impulses previously applied since the last call to World:update will be lost. 
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setAngularVelocity)
+---
 ---@param w number # The new angular velocity, in radians per second
 function Body:setAngularVelocity(w) end
 
 ---
 ---Wakes the body up or puts it to sleep.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setAwake)
 ---
 ---@param awake boolean # The body sleep status.
 function Body:setAwake(awake) end
@@ -740,6 +953,9 @@ function Body:setAwake(awake) end
 ---
 ---Note that static bodies (with zero mass) always use CCD, so your walls will not let a fast moving body pass through even if it is not a bullet.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setBullet)
+---
 ---@param status boolean # The bullet status of the body.
 function Body:setBullet(status) end
 
@@ -748,17 +964,26 @@ function Body:setBullet(status) end
 ---
 ---Bodies with fixed rotation don't vary the speed at which they rotate. Calling this function causes the mass to be reset. 
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setFixedRotation)
+---
 ---@param isFixed boolean # Whether the body should have fixed rotation.
 function Body:setFixedRotation(isFixed) end
 
 ---
 ---Sets a new gravity scale factor for the body.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setGravityScale)
+---
 ---@param scale number # The new gravity scale factor.
 function Body:setGravityScale(scale) end
 
 ---
 ---Set the inertia of a body.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setInertia)
 ---
 ---@param inertia number # The new moment of inertia, in kilograms * pixel squared.
 function Body:setInertia(inertia) end
@@ -770,6 +995,9 @@ function Body:setInertia(inertia) end
 ---
 ---Linear damping can take any value from 0 to infinity. It is recommended to stay between 0 and 0.1, though. Other values will make the objects look 'floaty'(if gravity is enabled).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setLinearDamping)
+---
 ---@param ld number # The new linear damping
 function Body:setLinearDamping(ld) end
 
@@ -778,6 +1006,9 @@ function Body:setLinearDamping(ld) end
 ---
 ---This function will not accumulate anything; any impulses previously applied since the last call to World:update will be lost.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setLinearVelocity)
+---
 ---@param x number # The x-component of the velocity vector.
 ---@param y number # The y-component of the velocity vector.
 function Body:setLinearVelocity(x, y) end
@@ -785,11 +1016,17 @@ function Body:setLinearVelocity(x, y) end
 ---
 ---Sets a new body mass.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setMass)
+---
 ---@param mass number # The mass, in kilograms.
 function Body:setMass(mass) end
 
 ---
 ---Overrides the calculated mass data.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setMassData)
 ---
 ---@param x number # The x position of the center of mass.
 ---@param y number # The y position of the center of mass.
@@ -804,12 +1041,18 @@ function Body:setMassData(x, y, mass, inertia) end
 ---
 ---This function cannot wake up the body.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setPosition)
+---
 ---@param x number # The x position.
 ---@param y number # The y position.
 function Body:setPosition(x, y) end
 
 ---
 ---Sets the sleeping behaviour of the body. Should sleeping be allowed, a body at rest will automatically sleep. A sleeping body is not simulated unless it collided with an awake body. Be wary that one can end up with a situation like a floating sleeping body if the floor was removed.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setSleepingAllowed)
 ---
 ---@param allowed boolean # True if the body is allowed to sleep or false if not.
 function Body:setSleepingAllowed(allowed) end
@@ -821,6 +1064,9 @@ function Body:setSleepingAllowed(allowed) end
 ---
 ---This function cannot wake up the body.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setTransform)
+---
 ---@param x number # The x component of the position.
 ---@param y number # The y component of the position.
 ---@param angle number # The angle in radians.
@@ -828,6 +1074,9 @@ function Body:setTransform(x, y, angle) end
 
 ---
 ---Sets a new body type.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setType)
 ---
 ---@param type love.BodyType # The new type.
 function Body:setType(type) end
@@ -837,6 +1086,9 @@ function Body:setType(type) end
 ---
 ---To delete the reference, explicitly pass nil.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setUserData)
+---
 ---@param value any # The Lua value to associate with the Body.
 function Body:setUserData(value) end
 
@@ -844,6 +1096,9 @@ function Body:setUserData(value) end
 ---Set the x position of the body.
 ---
 ---This function cannot wake up the body. 
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setX)
 ---
 ---@param x number # The x position.
 function Body:setX(x) end
@@ -853,6 +1108,9 @@ function Body:setX(x) end
 ---
 ---This function cannot wake up the body. 
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Body:setY)
+---
 ---@param y number # The y position.
 function Body:setY(y) end
 
@@ -861,11 +1119,17 @@ function Body:setY(y) end
 ---
 ---Unlike the PolygonShape, the ChainShape does not have a vertices limit or has to form a convex shape, but self intersections are not supported.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
+---
 ---@class love.ChainShape: love.Shape, love.Object
 local ChainShape = {}
 
 ---
 ---Returns a child of the shape as an EdgeShape.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ChainShape:getChildEdge)
 ---
 ---@param index number # The index of the child.
 ---@return love.EdgeShape shape # The child as an EdgeShape.
@@ -876,12 +1140,18 @@ function ChainShape:getChildEdge(index) end
 ---
 ---Setting next and previous ChainShape vertices can help prevent unwanted collisions when a flat shape slides along the edge and moves over to the new shape.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ChainShape:getNextVertex)
+---
 ---@return number x # The x-component of the vertex, or nil if ChainShape:setNextVertex hasn't been called.
 ---@return number y # The y-component of the vertex, or nil if ChainShape:setNextVertex hasn't been called.
 function ChainShape:getNextVertex() end
 
 ---
 ---Returns a point of the shape.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ChainShape:getPoint)
 ---
 ---@param index number # The index of the point to return.
 ---@return number x # The x-coordinate of the point.
@@ -890,6 +1160,9 @@ function ChainShape:getPoint(index) end
 
 ---
 ---Returns all points of the shape.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ChainShape:getPoints)
 ---
 ---@return number x1 # The x-coordinate of the first point.
 ---@return number y1 # The y-coordinate of the first point.
@@ -902,12 +1175,18 @@ function ChainShape:getPoints() end
 ---
 ---Setting next and previous ChainShape vertices can help prevent unwanted collisions when a flat shape slides along the edge and moves over to the new shape.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ChainShape:getPreviousVertex)
+---
 ---@return number x # The x-component of the vertex, or nil if ChainShape:setPreviousVertex hasn't been called.
 ---@return number y # The y-component of the vertex, or nil if ChainShape:setPreviousVertex hasn't been called.
 function ChainShape:getPreviousVertex() end
 
 ---
 ---Returns the number of vertices the shape has.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ChainShape:getVertexCount)
 ---
 ---@return number count # The number of vertices.
 function ChainShape:getVertexCount() end
@@ -916,6 +1195,9 @@ function ChainShape:getVertexCount() end
 ---Sets a vertex that establishes a connection to the next shape.
 ---
 ---This can help prevent unwanted collisions when a flat shape slides along the edge and moves over to the new shape.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ChainShape:setNextVertex)
 ---
 ---@param x number # The x-component of the vertex.
 ---@param y number # The y-component of the vertex.
@@ -926,6 +1208,9 @@ function ChainShape:setNextVertex(x, y) end
 ---
 ---This can help prevent unwanted collisions when a flat shape slides along the edge and moves over to the new shape.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/ChainShape:setPreviousVertex)
+---
 ---@param x number # The x-component of the vertex.
 ---@param y number # The y-component of the vertex.
 function ChainShape:setPreviousVertex(x, y) end
@@ -933,11 +1218,17 @@ function ChainShape:setPreviousVertex(x, y) end
 ---
 ---Circle extends Shape and adds a radius and a local position.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
+---
 ---@class love.CircleShape: love.Shape, love.Object
 local CircleShape = {}
 
 ---
 ---Gets the center point of the circle shape.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/CircleShape:getPoint)
 ---
 ---@return number x # The x-component of the center point of the circle.
 ---@return number y # The y-component of the center point of the circle.
@@ -946,11 +1237,17 @@ function CircleShape:getPoint() end
 ---
 ---Gets the radius of the circle shape.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/CircleShape:getRadius)
+---
 ---@return number radius # The radius of the circle
 function CircleShape:getRadius() end
 
 ---
 ---Sets the location of the center of the circle shape.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/CircleShape:setPoint)
 ---
 ---@param x number # The x-component of the new center point of the circle.
 ---@param y number # The y-component of the new center point of the circle.
@@ -959,11 +1256,17 @@ function CircleShape:setPoint(x, y) end
 ---
 ---Sets the radius of the circle.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/CircleShape:setRadius)
+---
 ---@param radius number # The radius of the circle
 function CircleShape:setRadius(radius) end
 
 ---
 ---Contacts are objects created to manage collisions in worlds.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
 ---
 ---@class love.Contact: love.Object
 local Contact = {}
@@ -972,6 +1275,9 @@ local Contact = {}
 ---Gets the child indices of the shapes of the two colliding fixtures. For ChainShapes, an index of 1 is the first edge in the chain.
 ---Used together with Fixture:rayCast or ChainShape:getChildEdge.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Contact:getChildren)
+---
 ---@return number indexA # The child index of the first fixture's shape.
 ---@return number indexB # The child index of the second fixture's shape.
 function Contact:getChildren() end
@@ -979,12 +1285,18 @@ function Contact:getChildren() end
 ---
 ---Gets the two Fixtures that hold the shapes that are in contact.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Contact:getFixtures)
+---
 ---@return love.Fixture fixtureA # The first Fixture.
 ---@return love.Fixture fixtureB # The second Fixture.
 function Contact:getFixtures() end
 
 ---
 ---Get the friction between two shapes that are in contact.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Contact:getFriction)
 ---
 ---@return number friction # The friction of the contact.
 function Contact:getFriction() end
@@ -994,12 +1306,18 @@ function Contact:getFriction() end
 ---
 ---This function returns the coordinates of a unit vector that points from the first shape to the second.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Contact:getNormal)
+---
 ---@return number nx # The x component of the normal vector.
 ---@return number ny # The y component of the normal vector.
 function Contact:getNormal() end
 
 ---
 ---Returns the contact points of the two colliding fixtures. There can be one or two points.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Contact:getPositions)
 ---
 ---@return number x1 # The x coordinate of the first contact point.
 ---@return number y1 # The y coordinate of the first contact point.
@@ -1010,11 +1328,17 @@ function Contact:getPositions() end
 ---
 ---Get the restitution between two shapes that are in contact.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Contact:getRestitution)
+---
 ---@return number restitution # The restitution between the two shapes.
 function Contact:getRestitution() end
 
 ---
 ---Returns whether the contact is enabled. The collision will be ignored if a contact gets disabled in the preSolve callback.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Contact:isEnabled)
 ---
 ---@return boolean enabled # True if enabled, false otherwise.
 function Contact:isEnabled() end
@@ -1022,21 +1346,33 @@ function Contact:isEnabled() end
 ---
 ---Returns whether the two colliding fixtures are touching each other.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Contact:isTouching)
+---
 ---@return boolean touching # True if they touch or false if not.
 function Contact:isTouching() end
 
 ---
 ---Resets the contact friction to the mixture value of both fixtures.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Contact:resetFriction)
+---
 function Contact:resetFriction() end
 
 ---
 ---Resets the contact restitution to the mixture value of both fixtures.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Contact:resetRestitution)
+---
 function Contact:resetRestitution() end
 
 ---
 ---Enables or disables the contact.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Contact:setEnabled)
 ---
 ---@param enabled boolean # True to enable or false to disable.
 function Contact:setEnabled(enabled) end
@@ -1044,11 +1380,17 @@ function Contact:setEnabled(enabled) end
 ---
 ---Sets the contact friction.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Contact:setFriction)
+---
 ---@param friction number # The contact friction.
 function Contact:setFriction(friction) end
 
 ---
 ---Sets the contact restitution.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Contact:setRestitution)
 ---
 ---@param restitution number # The contact restitution.
 function Contact:setRestitution(restitution) end
@@ -1056,11 +1398,17 @@ function Contact:setRestitution(restitution) end
 ---
 ---Keeps two bodies at the same distance.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
+---
 ---@class love.DistanceJoint: love.Joint, love.Object
 local DistanceJoint = {}
 
 ---
 ---Gets the damping ratio.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/DistanceJoint:getDampingRatio)
 ---
 ---@return number ratio # The damping ratio.
 function DistanceJoint:getDampingRatio() end
@@ -1068,11 +1416,17 @@ function DistanceJoint:getDampingRatio() end
 ---
 ---Gets the response speed.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/DistanceJoint:getFrequency)
+---
 ---@return number Hz # The response speed.
 function DistanceJoint:getFrequency() end
 
 ---
 ---Gets the equilibrium distance between the two Bodies.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/DistanceJoint:getLength)
 ---
 ---@return number l # The length between the two Bodies.
 function DistanceJoint:getLength() end
@@ -1080,11 +1434,17 @@ function DistanceJoint:getLength() end
 ---
 ---Sets the damping ratio.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/DistanceJoint:setDampingRatio)
+---
 ---@param ratio number # The damping ratio.
 function DistanceJoint:setDampingRatio(ratio) end
 
 ---
 ---Sets the response speed.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/DistanceJoint:setFrequency)
 ---
 ---@param Hz number # The response speed.
 function DistanceJoint:setFrequency(Hz) end
@@ -1092,11 +1452,17 @@ function DistanceJoint:setFrequency(Hz) end
 ---
 ---Sets the equilibrium distance between the two Bodies.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/DistanceJoint:setLength)
+---
 ---@param l number # The length between the two Bodies.
 function DistanceJoint:setLength(l) end
 
 ---
 ---A EdgeShape is a line segment. They can be used to create the boundaries of your terrain. The shape does not have volume and can only collide with PolygonShape and CircleShape.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
 ---
 ---@class love.EdgeShape: love.Shape, love.Object
 local EdgeShape = {}
@@ -1106,12 +1472,18 @@ local EdgeShape = {}
 ---
 ---Setting next and previous EdgeShape vertices can help prevent unwanted collisions when a flat shape slides along the edge and moves over to the new shape.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/EdgeShape:getNextVertex)
+---
 ---@return number x # The x-component of the vertex, or nil if EdgeShape:setNextVertex hasn't been called.
 ---@return number y # The y-component of the vertex, or nil if EdgeShape:setNextVertex hasn't been called.
 function EdgeShape:getNextVertex() end
 
 ---
 ---Returns the local coordinates of the edge points.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/EdgeShape:getPoints)
 ---
 ---@return number x1 # The x-component of the first vertex.
 ---@return number y1 # The y-component of the first vertex.
@@ -1124,6 +1496,9 @@ function EdgeShape:getPoints() end
 ---
 ---Setting next and previous EdgeShape vertices can help prevent unwanted collisions when a flat shape slides along the edge and moves over to the new shape.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/EdgeShape:getPreviousVertex)
+---
 ---@return number x # The x-component of the vertex, or nil if EdgeShape:setPreviousVertex hasn't been called.
 ---@return number y # The y-component of the vertex, or nil if EdgeShape:setPreviousVertex hasn't been called.
 function EdgeShape:getPreviousVertex() end
@@ -1132,6 +1507,9 @@ function EdgeShape:getPreviousVertex() end
 ---Sets a vertex that establishes a connection to the next shape.
 ---
 ---This can help prevent unwanted collisions when a flat shape slides along the edge and moves over to the new shape.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/EdgeShape:setNextVertex)
 ---
 ---@param x number # The x-component of the vertex.
 ---@param y number # The y-component of the vertex.
@@ -1142,6 +1520,9 @@ function EdgeShape:setNextVertex(x, y) end
 ---
 ---This can help prevent unwanted collisions when a flat shape slides along the edge and moves over to the new shape.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/EdgeShape:setPreviousVertex)
+---
 ---@param x number # The x-component of the vertex.
 ---@param y number # The y-component of the vertex.
 function EdgeShape:setPreviousVertex(x, y) end
@@ -1149,22 +1530,34 @@ function EdgeShape:setPreviousVertex(x, y) end
 ---
 ---Fixtures attach shapes to bodies.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
+---
 ---@class love.Fixture: love.Object
 local Fixture = {}
 
 ---
 ---Destroys the fixture.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:destroy)
+---
 function Fixture:destroy() end
 
 ---
 ---Returns the body to which the fixture is attached.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:getBody)
 ---
 ---@return love.Body body # The parent body.
 function Fixture:getBody() end
 
 ---
 ---Returns the points of the fixture bounding box. In case the fixture has multiple children a 1-based index can be specified. For example, a fixture will have multiple children with a chain shape.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:getBoundingBox)
 ---
 ---@param index? number # A bounding box of the fixture.
 ---@return number topLeftX # The x position of the top-left point.
@@ -1176,12 +1569,18 @@ function Fixture:getBoundingBox(index) end
 ---
 ---Returns the categories the fixture belongs to.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:getCategory)
+---
 ---@return number category1 # The first category.
 ---@return number category2 # The second category.
 function Fixture:getCategory() end
 
 ---
 ---Returns the density of the fixture.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:getDensity)
 ---
 ---@return number density # The fixture density in kilograms per square meter.
 function Fixture:getDensity() end
@@ -1191,6 +1590,9 @@ function Fixture:getDensity() end
 ---
 ---Categories and masks are encoded as the bits of a 16-bit integer.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:getFilterData)
+---
 ---@return number categories # The categories as an integer from 0 to 65535.
 ---@return number mask # The mask as an integer from 0 to 65535.
 ---@return number group # The group as an integer from -32768 to 32767.
@@ -1198,6 +1600,9 @@ function Fixture:getFilterData() end
 
 ---
 ---Returns the friction of the fixture.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:getFriction)
 ---
 ---@return number friction # The fixture friction.
 function Fixture:getFriction() end
@@ -1207,11 +1612,17 @@ function Fixture:getFriction() end
 ---
 ---The groups range from -32768 to 32767.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:getGroupIndex)
+---
 ---@return number group # The group of the fixture.
 function Fixture:getGroupIndex() end
 
 ---
 ---Returns which categories this fixture should '''NOT''' collide with.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:getMask)
 ---
 ---@return number mask1 # The first category selected by the mask.
 ---@return number mask2 # The second category selected by the mask.
@@ -1219,6 +1630,9 @@ function Fixture:getMask() end
 
 ---
 ---Returns the mass, its center and the rotational inertia.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:getMassData)
 ---
 ---@return number x # The x position of the center of mass.
 ---@return number y # The y position of the center of mass.
@@ -1229,11 +1643,17 @@ function Fixture:getMassData() end
 ---
 ---Returns the restitution of the fixture.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:getRestitution)
+---
 ---@return number restitution # The fixture restitution.
 function Fixture:getRestitution() end
 
 ---
 ---Returns the shape of the fixture. This shape is a reference to the actual data used in the simulation. It's possible to change its values between timesteps.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:getShape)
 ---
 ---@return love.Shape shape # The fixture's shape.
 function Fixture:getShape() end
@@ -1241,17 +1661,26 @@ function Fixture:getShape() end
 ---
 ---Returns the Lua value associated with this fixture.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:getUserData)
+---
 ---@return any value # The Lua value associated with the fixture.
 function Fixture:getUserData() end
 
 ---
 ---Gets whether the Fixture is destroyed. Destroyed fixtures cannot be used.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:isDestroyed)
+---
 ---@return boolean destroyed # Whether the Fixture is destroyed.
 function Fixture:isDestroyed() end
 
 ---
 ---Returns whether the fixture is a sensor.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:isSensor)
 ---
 ---@return boolean sensor # If the fixture is a sensor.
 function Fixture:isSensor() end
@@ -1266,6 +1695,9 @@ function Fixture:isSensor() end
 ---The world position of the impact can be calculated by multiplying the line vector with the third return value and adding it to the line starting point.
 ---
 ---hitx, hity = x1 + (x2 - x1) * fraction, y1 + (y2 - y1) * fraction
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:rayCast)
 ---
 ---@param x1 number # The x position of the input line starting point.
 ---@param y1 number # The y position of the input line starting point.
@@ -1283,12 +1715,18 @@ function Fixture:rayCast(x1, y1, x2, y2, maxFraction, childIndex) end
 ---
 ---All fixture's default category is 1.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:setCategory)
+---
 ---@param category1 number # The first category.
 ---@param category2 number # The second category.
 function Fixture:setCategory(category1, category2) end
 
 ---
 ---Sets the density of the fixture. Call Body:resetMassData if this needs to take effect immediately.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:setDensity)
 ---
 ---@param density number # The fixture density in kilograms per square meter.
 function Fixture:setDensity(density) end
@@ -1306,6 +1744,9 @@ function Fixture:setDensity(density) end
 ---
 ---This function allows setting all filter data for a fixture at once. To set only the categories, the mask or the group, you can use Fixture:setCategory, Fixture:setMask or Fixture:setGroupIndex respectively.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:setFilterData)
+---
 ---@param categories number # The categories as an integer from 0 to 65535.
 ---@param mask number # The mask as an integer from 0 to 65535.
 ---@param group number # The group as an integer from -32768 to 32767.
@@ -1316,6 +1757,9 @@ function Fixture:setFilterData(categories, mask, group) end
 ---
 ---Friction determines how shapes react when they 'slide' along other shapes. Low friction indicates a slippery surface, like ice, while high friction indicates a rough surface, like concrete. Range: 0.0 - 1.0.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:setFriction)
+---
 ---@param friction number # The fixture friction.
 function Fixture:setFriction(friction) end
 
@@ -1323,6 +1767,9 @@ function Fixture:setFriction(friction) end
 ---Sets the group the fixture belongs to. Fixtures with the same group will always collide if the group is positive or never collide if it's negative. The group zero means no group.
 ---
 ---The groups range from -32768 to 32767.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:setGroupIndex)
 ---
 ---@param group number # The group as an integer from -32768 to 32767.
 function Fixture:setGroupIndex(group) end
@@ -1332,12 +1779,18 @@ function Fixture:setGroupIndex(group) end
 ---
 ---This fixture will '''NOT''' collide with the fixtures that are in the selected categories if the other fixture also has a category of this fixture selected.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:setMask)
+---
 ---@param mask1 number # The first category.
 ---@param mask2 number # The second category.
 function Fixture:setMask(mask1, mask2) end
 
 ---
 ---Sets the restitution of the fixture.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:setRestitution)
 ---
 ---@param restitution number # The fixture restitution.
 function Fixture:setRestitution(restitution) end
@@ -1347,6 +1800,9 @@ function Fixture:setRestitution(restitution) end
 ---
 ---Sensors do not cause collision responses, but the begin-contact and end-contact World callbacks will still be called for this fixture.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:setSensor)
+---
 ---@param sensor boolean # The sensor status.
 function Fixture:setSensor(sensor) end
 
@@ -1355,11 +1811,17 @@ function Fixture:setSensor(sensor) end
 ---
 ---To delete the reference, explicitly pass nil.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:setUserData)
+---
 ---@param value any # The Lua value to associate with the fixture.
 function Fixture:setUserData(value) end
 
 ---
 ---Checks if a point is inside the shape of the fixture.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Fixture:testPoint)
 ---
 ---@param x number # The x position of the point.
 ---@param y number # The y position of the point.
@@ -1369,11 +1831,17 @@ function Fixture:testPoint(x, y) end
 ---
 ---A FrictionJoint applies friction to a body.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
+---
 ---@class love.FrictionJoint: love.Joint, love.Object
 local FrictionJoint = {}
 
 ---
 ---Gets the maximum friction force in Newtons.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/FrictionJoint:getMaxForce)
 ---
 ---@return number force # Maximum force in Newtons.
 function FrictionJoint:getMaxForce() end
@@ -1381,11 +1849,17 @@ function FrictionJoint:getMaxForce() end
 ---
 ---Gets the maximum friction torque in Newton-meters.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/FrictionJoint:getMaxTorque)
+---
 ---@return number torque # Maximum torque in Newton-meters.
 function FrictionJoint:getMaxTorque() end
 
 ---
 ---Sets the maximum friction force in Newtons.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/FrictionJoint:setMaxForce)
 ---
 ---@param maxForce number # Max force in Newtons.
 function FrictionJoint:setMaxForce(maxForce) end
@@ -1393,17 +1867,26 @@ function FrictionJoint:setMaxForce(maxForce) end
 ---
 ---Sets the maximum friction torque in Newton-meters.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/FrictionJoint:setMaxTorque)
+---
 ---@param torque number # Maximum torque in Newton-meters.
 function FrictionJoint:setMaxTorque(torque) end
 
 ---
 ---Keeps bodies together in such a way that they act like gears.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
+---
 ---@class love.GearJoint: love.Joint, love.Object
 local GearJoint = {}
 
 ---
 ---Get the Joints connected by this GearJoint.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/GearJoint:getJoints)
 ---
 ---@return love.Joint joint1 # The first connected Joint.
 ---@return love.Joint joint2 # The second connected Joint.
@@ -1412,17 +1895,26 @@ function GearJoint:getJoints() end
 ---
 ---Get the ratio of a gear joint.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/GearJoint:getRatio)
+---
 ---@return number ratio # The ratio of the joint.
 function GearJoint:getRatio() end
 
 ---
 ---Set the ratio of a gear joint.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/GearJoint:setRatio)
+---
 ---@param ratio number # The new ratio of the joint.
 function GearJoint:setRatio(ratio) end
 
 ---
 ---Attach multiple bodies together to interact in unique ways.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
 ---
 ---@class love.Joint: love.Object
 local Joint = {}
@@ -1434,10 +1926,16 @@ local Joint = {}
 ---
 ---may be used to free the object immediately.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Joint:destroy)
+---
 function Joint:destroy() end
 
 ---
 ---Get the anchor points of the joint.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Joint:getAnchors)
 ---
 ---@return number x1 # The x-component of the anchor on Body 1.
 ---@return number y1 # The y-component of the anchor on Body 1.
@@ -1448,6 +1946,9 @@ function Joint:getAnchors() end
 ---
 ---Gets the bodies that the Joint is attached to.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Joint:getBodies)
+---
 ---@return love.Body bodyA # The first Body.
 ---@return love.Body bodyB # The second Body.
 function Joint:getBodies() end
@@ -1455,11 +1956,17 @@ function Joint:getBodies() end
 ---
 ---Gets whether the connected Bodies collide.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Joint:getCollideConnected)
+---
 ---@return boolean c # True if they collide, false otherwise.
 function Joint:getCollideConnected() end
 
 ---
 ---Returns the reaction force in newtons on the second body
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Joint:getReactionForce)
 ---
 ---@param x number # How long the force applies. Usually the inverse time step or 1/dt.
 ---@return number x # The x-component of the force.
@@ -1469,6 +1976,9 @@ function Joint:getReactionForce(x) end
 ---
 ---Returns the reaction torque on the second body.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Joint:getReactionTorque)
+---
 ---@param invdt number # How long the force applies. Usually the inverse time step or 1/dt.
 ---@return number torque # The reaction torque on the second body.
 function Joint:getReactionTorque(invdt) end
@@ -1476,17 +1986,26 @@ function Joint:getReactionTorque(invdt) end
 ---
 ---Gets a string representing the type.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Joint:getType)
+---
 ---@return love.JointType type # A string with the name of the Joint type.
 function Joint:getType() end
 
 ---
 ---Returns the Lua value associated with this Joint.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Joint:getUserData)
+---
 ---@return any value # The Lua value associated with the Joint.
 function Joint:getUserData() end
 
 ---
 ---Gets whether the Joint is destroyed. Destroyed joints cannot be used.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Joint:isDestroyed)
 ---
 ---@return boolean destroyed # Whether the Joint is destroyed.
 function Joint:isDestroyed() end
@@ -1496,11 +2015,17 @@ function Joint:isDestroyed() end
 ---
 ---To delete the reference, explicitly pass nil.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Joint:setUserData)
+---
 ---@param value any # The Lua value to associate with the Joint.
 function Joint:setUserData(value) end
 
 ---
 ---Controls the relative motion between two Bodies. Position and rotation offsets can be specified, as well as the maximum motor force and torque that will be applied to reach the target offsets.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
 ---
 ---@class love.MotorJoint: love.Joint, love.Object
 local MotorJoint = {}
@@ -1508,11 +2033,17 @@ local MotorJoint = {}
 ---
 ---Gets the target angular offset between the two Bodies the Joint is attached to.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/MotorJoint:getAngularOffset)
+---
 ---@return number angleoffset # The target angular offset in radians: the second body's angle minus the first body's angle.
 function MotorJoint:getAngularOffset() end
 
 ---
 ---Gets the target linear offset between the two Bodies the Joint is attached to.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/MotorJoint:getLinearOffset)
 ---
 ---@return number x # The x component of the target linear offset, relative to the first Body.
 ---@return number y # The y component of the target linear offset, relative to the first Body.
@@ -1521,11 +2052,17 @@ function MotorJoint:getLinearOffset() end
 ---
 ---Sets the target angluar offset between the two Bodies the Joint is attached to.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/MotorJoint:setAngularOffset)
+---
 ---@param angleoffset number # The target angular offset in radians: the second body's angle minus the first body's angle.
 function MotorJoint:setAngularOffset(angleoffset) end
 
 ---
 ---Sets the target linear offset between the two Bodies the Joint is attached to.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/MotorJoint:setLinearOffset)
 ---
 ---@param x number # The x component of the target linear offset, relative to the first Body.
 ---@param y number # The y component of the target linear offset, relative to the first Body.
@@ -1534,11 +2071,17 @@ function MotorJoint:setLinearOffset(x, y) end
 ---
 ---For controlling objects with the mouse.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
+---
 ---@class love.MouseJoint: love.Joint, love.Object
 local MouseJoint = {}
 
 ---
 ---Returns the damping ratio.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/MouseJoint:getDampingRatio)
 ---
 ---@return number ratio # The new damping ratio.
 function MouseJoint:getDampingRatio() end
@@ -1546,17 +2089,26 @@ function MouseJoint:getDampingRatio() end
 ---
 ---Returns the frequency.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/MouseJoint:getFrequency)
+---
 ---@return number freq # The frequency in hertz.
 function MouseJoint:getFrequency() end
 
 ---
 ---Gets the highest allowed force.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/MouseJoint:getMaxForce)
+---
 ---@return number f # The max allowed force.
 function MouseJoint:getMaxForce() end
 
 ---
 ---Gets the target point.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/MouseJoint:getTarget)
 ---
 ---@return number x # The x-component of the target.
 ---@return number y # The x-component of the target.
@@ -1565,11 +2117,17 @@ function MouseJoint:getTarget() end
 ---
 ---Sets a new damping ratio.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/MouseJoint:setDampingRatio)
+---
 ---@param ratio number # The new damping ratio.
 function MouseJoint:setDampingRatio(ratio) end
 
 ---
 ---Sets a new frequency.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/MouseJoint:setFrequency)
 ---
 ---@param freq number # The new frequency in hertz.
 function MouseJoint:setFrequency(freq) end
@@ -1577,11 +2135,17 @@ function MouseJoint:setFrequency(freq) end
 ---
 ---Sets the highest allowed force.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/MouseJoint:setMaxForce)
+---
 ---@param f number # The max allowed force.
 function MouseJoint:setMaxForce(f) end
 
 ---
 ---Sets the target point.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/MouseJoint:setTarget)
 ---
 ---@param x number # The x-component of the target.
 ---@param y number # The y-component of the target.
@@ -1590,6 +2154,9 @@ function MouseJoint:setTarget(x, y) end
 ---
 ---A PolygonShape is a convex polygon with up to 8 vertices.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
+---
 ---@class love.PolygonShape: love.Shape, love.Object
 local PolygonShape = {}
 
@@ -1597,6 +2164,9 @@ local PolygonShape = {}
 ---Get the local coordinates of the polygon's vertices.
 ---
 ---This function has a variable number of return values. It can be used in a nested fashion with love.graphics.polygon.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/PolygonShape:getPoints)
 ---
 ---@return number x1 # The x-component of the first vertex.
 ---@return number y1 # The y-component of the first vertex.
@@ -1607,17 +2177,26 @@ function PolygonShape:getPoints() end
 ---
 ---Restricts relative motion between Bodies to one shared axis.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
+---
 ---@class love.PrismaticJoint: love.Joint, love.Object
 local PrismaticJoint = {}
 
 ---
 ---Checks whether the limits are enabled.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:areLimitsEnabled)
+---
 ---@return boolean enabled # True if enabled, false otherwise.
 function PrismaticJoint:areLimitsEnabled() end
 
 ---
 ---Gets the world-space axis vector of the Prismatic Joint.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:getAxis)
 ---
 ---@return number x # The x-axis coordinate of the world-space axis vector.
 ---@return number y # The y-axis coordinate of the world-space axis vector.
@@ -1626,17 +2205,26 @@ function PrismaticJoint:getAxis() end
 ---
 ---Get the current joint angle speed.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:getJointSpeed)
+---
 ---@return number s # Joint angle speed in meters/second.
 function PrismaticJoint:getJointSpeed() end
 
 ---
 ---Get the current joint translation.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:getJointTranslation)
+---
 ---@return number t # Joint translation, usually in meters..
 function PrismaticJoint:getJointTranslation() end
 
 ---
 ---Gets the joint limits.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:getLimits)
 ---
 ---@return number lower # The lower limit, usually in meters.
 ---@return number upper # The upper limit, usually in meters.
@@ -1645,17 +2233,26 @@ function PrismaticJoint:getLimits() end
 ---
 ---Gets the lower limit.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:getLowerLimit)
+---
 ---@return number lower # The lower limit, usually in meters.
 function PrismaticJoint:getLowerLimit() end
 
 ---
 ---Gets the maximum motor force.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:getMaxMotorForce)
+---
 ---@return number f # The maximum motor force, usually in N.
 function PrismaticJoint:getMaxMotorForce() end
 
 ---
 ---Returns the current motor force.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:getMotorForce)
 ---
 ---@param invdt number # How long the force applies. Usually the inverse time step or 1/dt.
 ---@return number force # The force on the motor in newtons.
@@ -1664,11 +2261,17 @@ function PrismaticJoint:getMotorForce(invdt) end
 ---
 ---Gets the motor speed.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:getMotorSpeed)
+---
 ---@return number s # The motor speed, usually in meters per second.
 function PrismaticJoint:getMotorSpeed() end
 
 ---
 ---Gets the reference angle.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:getReferenceAngle)
 ---
 ---@return number angle # The reference angle in radians.
 function PrismaticJoint:getReferenceAngle() end
@@ -1676,17 +2279,26 @@ function PrismaticJoint:getReferenceAngle() end
 ---
 ---Gets the upper limit.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:getUpperLimit)
+---
 ---@return number upper # The upper limit, usually in meters.
 function PrismaticJoint:getUpperLimit() end
 
 ---
 ---Checks whether the motor is enabled.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:isMotorEnabled)
+---
 ---@return boolean enabled # True if enabled, false if disabled.
 function PrismaticJoint:isMotorEnabled() end
 
 ---
 ---Sets the limits.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:setLimits)
 ---
 ---@param lower number # The lower limit, usually in meters.
 ---@param upper number # The upper limit, usually in meters.
@@ -1695,11 +2307,17 @@ function PrismaticJoint:setLimits(lower, upper) end
 ---
 ---Enables/disables the joint limit.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:setLimitsEnabled)
+---
 ---@return boolean enable # True if enabled, false if disabled.
 function PrismaticJoint:setLimitsEnabled() end
 
 ---
 ---Sets the lower limit.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:setLowerLimit)
 ---
 ---@param lower number # The lower limit, usually in meters.
 function PrismaticJoint:setLowerLimit(lower) end
@@ -1707,11 +2325,17 @@ function PrismaticJoint:setLowerLimit(lower) end
 ---
 ---Set the maximum motor force.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:setMaxMotorForce)
+---
 ---@param f number # The maximum motor force, usually in N.
 function PrismaticJoint:setMaxMotorForce(f) end
 
 ---
 ---Enables/disables the joint motor.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:setMotorEnabled)
 ---
 ---@param enable boolean # True to enable, false to disable.
 function PrismaticJoint:setMotorEnabled(enable) end
@@ -1719,11 +2343,17 @@ function PrismaticJoint:setMotorEnabled(enable) end
 ---
 ---Sets the motor speed.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:setMotorSpeed)
+---
 ---@param s number # The motor speed, usually in meters per second.
 function PrismaticJoint:setMotorSpeed(s) end
 
 ---
 ---Sets the upper limit.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/PrismaticJoint:setUpperLimit)
 ---
 ---@param upper number # The upper limit, usually in meters.
 function PrismaticJoint:setUpperLimit(upper) end
@@ -1731,17 +2361,26 @@ function PrismaticJoint:setUpperLimit(upper) end
 ---
 ---Allows you to simulate bodies connected through pulleys.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
+---
 ---@class love.PulleyJoint: love.Joint, love.Object
 local PulleyJoint = {}
 
 ---
 ---Get the total length of the rope.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/PulleyJoint:getConstant)
+---
 ---@return number length # The length of the rope in the joint.
 function PulleyJoint:getConstant() end
 
 ---
 ---Get the ground anchor positions in world coordinates.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/PulleyJoint:getGroundAnchors)
 ---
 ---@return number a1x # The x coordinate of the first anchor.
 ---@return number a1y # The y coordinate of the first anchor.
@@ -1752,11 +2391,17 @@ function PulleyJoint:getGroundAnchors() end
 ---
 ---Get the current length of the rope segment attached to the first body.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/PulleyJoint:getLengthA)
+---
 ---@return number length # The length of the rope segment.
 function PulleyJoint:getLengthA() end
 
 ---
 ---Get the current length of the rope segment attached to the second body.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/PulleyJoint:getLengthB)
 ---
 ---@return number length # The length of the rope segment.
 function PulleyJoint:getLengthB() end
@@ -1764,12 +2409,18 @@ function PulleyJoint:getLengthB() end
 ---
 ---Get the maximum lengths of the rope segments.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/PulleyJoint:getMaxLengths)
+---
 ---@return number len1 # The maximum length of the first rope segment.
 ---@return number len2 # The maximum length of the second rope segment.
 function PulleyJoint:getMaxLengths() end
 
 ---
 ---Get the pulley ratio.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/PulleyJoint:getRatio)
 ---
 ---@return number ratio # The pulley ratio of the joint.
 function PulleyJoint:getRatio() end
@@ -1779,6 +2430,9 @@ function PulleyJoint:getRatio() end
 ---
 ---Setting a new length for the rope updates the maximum length values of the joint.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/PulleyJoint:setConstant)
+---
 ---@param length number # The new length of the rope in the joint.
 function PulleyJoint:setConstant(length) end
 
@@ -1787,6 +2441,9 @@ function PulleyJoint:setConstant(length) end
 ---
 ---The physics module also imposes maximum values for the rope segments. If the parameters exceed these values, the maximum values are set instead of the requested values.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/PulleyJoint:setMaxLengths)
+---
 ---@param max1 number # The new maximum length of the first segment.
 ---@param max2 number # The new maximum length of the second segment.
 function PulleyJoint:setMaxLengths(max1, max2) end
@@ -1794,11 +2451,17 @@ function PulleyJoint:setMaxLengths(max1, max2) end
 ---
 ---Set the pulley ratio.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/PulleyJoint:setRatio)
+---
 ---@param ratio number # The new pulley ratio of the joint.
 function PulleyJoint:setRatio(ratio) end
 
 ---
 ---Allow two Bodies to revolve around a shared point.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
 ---
 ---@class love.RevoluteJoint: love.Joint, love.Object
 local RevoluteJoint = {}
@@ -1806,11 +2469,17 @@ local RevoluteJoint = {}
 ---
 ---Checks whether limits are enabled.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:areLimitsEnabled)
+---
 ---@return boolean enabled # True if enabled, false otherwise.
 function RevoluteJoint:areLimitsEnabled() end
 
 ---
 ---Get the current joint angle.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:getJointAngle)
 ---
 ---@return number angle # The joint angle in radians.
 function RevoluteJoint:getJointAngle() end
@@ -1818,11 +2487,17 @@ function RevoluteJoint:getJointAngle() end
 ---
 ---Get the current joint angle speed.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:getJointSpeed)
+---
 ---@return number s # Joint angle speed in radians/second.
 function RevoluteJoint:getJointSpeed() end
 
 ---
 ---Gets the joint limits.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:getLimits)
 ---
 ---@return number lower # The lower limit, in radians.
 ---@return number upper # The upper limit, in radians.
@@ -1831,11 +2506,17 @@ function RevoluteJoint:getLimits() end
 ---
 ---Gets the lower limit.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:getLowerLimit)
+---
 ---@return number lower # The lower limit, in radians.
 function RevoluteJoint:getLowerLimit() end
 
 ---
 ---Gets the maximum motor force.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:getMaxMotorTorque)
 ---
 ---@return number f # The maximum motor force, in Nm.
 function RevoluteJoint:getMaxMotorTorque() end
@@ -1843,11 +2524,17 @@ function RevoluteJoint:getMaxMotorTorque() end
 ---
 ---Gets the motor speed.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:getMotorSpeed)
+---
 ---@return number s # The motor speed, radians per second.
 function RevoluteJoint:getMotorSpeed() end
 
 ---
 ---Get the current motor force.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:getMotorTorque)
 ---
 ---@return number f # The current motor force, in Nm.
 function RevoluteJoint:getMotorTorque() end
@@ -1855,11 +2542,17 @@ function RevoluteJoint:getMotorTorque() end
 ---
 ---Gets the reference angle.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:getReferenceAngle)
+---
 ---@return number angle # The reference angle in radians.
 function RevoluteJoint:getReferenceAngle() end
 
 ---
 ---Gets the upper limit.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:getUpperLimit)
 ---
 ---@return number upper # The upper limit, in radians.
 function RevoluteJoint:getUpperLimit() end
@@ -1867,17 +2560,26 @@ function RevoluteJoint:getUpperLimit() end
 ---
 ---Checks whether limits are enabled.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:hasLimitsEnabled)
+---
 ---@return boolean enabled # True if enabled, false otherwise.
 function RevoluteJoint:hasLimitsEnabled() end
 
 ---
 ---Checks whether the motor is enabled.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:isMotorEnabled)
+---
 ---@return boolean enabled # True if enabled, false if disabled.
 function RevoluteJoint:isMotorEnabled() end
 
 ---
 ---Sets the limits.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:setLimits)
 ---
 ---@param lower number # The lower limit, in radians.
 ---@param upper number # The upper limit, in radians.
@@ -1886,11 +2588,17 @@ function RevoluteJoint:setLimits(lower, upper) end
 ---
 ---Enables/disables the joint limit.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:setLimitsEnabled)
+---
 ---@param enable boolean # True to enable, false to disable.
 function RevoluteJoint:setLimitsEnabled(enable) end
 
 ---
 ---Sets the lower limit.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:setLowerLimit)
 ---
 ---@param lower number # The lower limit, in radians.
 function RevoluteJoint:setLowerLimit(lower) end
@@ -1898,11 +2606,17 @@ function RevoluteJoint:setLowerLimit(lower) end
 ---
 ---Set the maximum motor force.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:setMaxMotorTorque)
+---
 ---@param f number # The maximum motor force, in Nm.
 function RevoluteJoint:setMaxMotorTorque(f) end
 
 ---
 ---Enables/disables the joint motor.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:setMotorEnabled)
 ---
 ---@param enable boolean # True to enable, false to disable.
 function RevoluteJoint:setMotorEnabled(enable) end
@@ -1910,11 +2624,17 @@ function RevoluteJoint:setMotorEnabled(enable) end
 ---
 ---Sets the motor speed.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:setMotorSpeed)
+---
 ---@param s number # The motor speed, radians per second.
 function RevoluteJoint:setMotorSpeed(s) end
 
 ---
 ---Sets the upper limit.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/RevoluteJoint:setUpperLimit)
 ---
 ---@param upper number # The upper limit, in radians.
 function RevoluteJoint:setUpperLimit(upper) end
@@ -1922,17 +2642,26 @@ function RevoluteJoint:setUpperLimit(upper) end
 ---
 ---The RopeJoint enforces a maximum distance between two points on two bodies. It has no other effect.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
+---
 ---@class love.RopeJoint: love.Joint, love.Object
 local RopeJoint = {}
 
 ---
 ---Gets the maximum length of a RopeJoint.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/RopeJoint:getMaxLength)
+---
 ---@return number maxLength # The maximum length of the RopeJoint.
 function RopeJoint:getMaxLength() end
 
 ---
 ---Sets the maximum length of a RopeJoint.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/RopeJoint:setMaxLength)
 ---
 ---@param maxLength number # The new maximum length of the RopeJoint.
 function RopeJoint:setMaxLength(maxLength) end
@@ -1944,11 +2673,17 @@ function RopeJoint:setMaxLength(maxLength) end
 ---
 ---The Shape's position is relative to the position of the Body it has been attached to.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
+---
 ---@class love.Shape: love.Object
 local Shape = {}
 
 ---
 ---Returns the points of the bounding box for the transformed shape.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Shape:computeAABB)
 ---
 ---@param tx number # The translation of the shape on the x-axis.
 ---@param ty number # The translation of the shape on the y-axis.
@@ -1963,6 +2698,9 @@ function Shape:computeAABB(tx, ty, tr, childIndex) end
 ---
 ---Computes the mass properties for the shape with the specified density.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Shape:computeMass)
+---
 ---@param density number # The shape density.
 ---@return number x # The x postition of the center of mass.
 ---@return number y # The y postition of the center of mass.
@@ -1973,11 +2711,17 @@ function Shape:computeMass(density) end
 ---
 ---Returns the number of children the shape has.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Shape:getChildCount)
+---
 ---@return number count # The number of children.
 function Shape:getChildCount() end
 
 ---
 ---Gets the radius of the shape.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Shape:getRadius)
 ---
 ---@return number radius # The radius of the shape.
 function Shape:getRadius() end
@@ -1986,6 +2730,9 @@ function Shape:getRadius() end
 ---Gets a string representing the Shape.
 ---
 ---This function can be useful for conditional debug drawing.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Shape:getType)
 ---
 ---@return love.ShapeType type # The type of the Shape.
 function Shape:getType() end
@@ -2000,6 +2747,9 @@ function Shape:getType() end
 ---The world position of the impact can be calculated by multiplying the line vector with the third return value and adding it to the line starting point.
 ---
 ---hitx, hity = x1 + (x2 - x1) * fraction, y1 + (y2 - y1) * fraction
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Shape:rayCast)
 ---
 ---@param x1 number # The x position of the input line starting point.
 ---@param y1 number # The y position of the input line starting point.
@@ -2018,6 +2768,9 @@ function Shape:rayCast(x1, y1, x2, y2, maxFraction, tx, ty, tr, childIndex) end
 ---
 ---This is particularly useful for mouse interaction with the shapes. By looping through all shapes and testing the mouse position with this function, we can find which shapes the mouse touches.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Shape:testPoint)
+---
 ---@param tx number # Translates the shape along the x-axis.
 ---@param ty number # Translates the shape along the y-axis.
 ---@param tr number # Rotates the shape.
@@ -2029,11 +2782,17 @@ function Shape:testPoint(tx, ty, tr, x, y) end
 ---
 ---A WeldJoint essentially glues two bodies together.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
+---
 ---@class love.WeldJoint: love.Joint, love.Object
 local WeldJoint = {}
 
 ---
 ---Returns the damping ratio of the joint.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/WeldJoint:getDampingRatio)
 ---
 ---@return number ratio # The damping ratio.
 function WeldJoint:getDampingRatio() end
@@ -2041,11 +2800,17 @@ function WeldJoint:getDampingRatio() end
 ---
 ---Returns the frequency.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/WeldJoint:getFrequency)
+---
 ---@return number freq # The frequency in hertz.
 function WeldJoint:getFrequency() end
 
 ---
 ---Gets the reference angle.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/WeldJoint:getReferenceAngle)
 ---
 ---@return number angle # The reference angle in radians.
 function WeldJoint:getReferenceAngle() end
@@ -2053,11 +2818,17 @@ function WeldJoint:getReferenceAngle() end
 ---
 ---Sets a new damping ratio.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/WeldJoint:setDampingRatio)
+---
 ---@param ratio number # The new damping ratio.
 function WeldJoint:setDampingRatio(ratio) end
 
 ---
 ---Sets a new frequency.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/WeldJoint:setFrequency)
 ---
 ---@param freq number # The new frequency in hertz.
 function WeldJoint:setFrequency(freq) end
@@ -2065,11 +2836,17 @@ function WeldJoint:setFrequency(freq) end
 ---
 ---Restricts a point on the second body to a line on the first body.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
+---
 ---@class love.WheelJoint: love.Joint, love.Object
 local WheelJoint = {}
 
 ---
 ---Gets the world-space axis vector of the Wheel Joint.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/WheelJoint:getAxis)
 ---
 ---@return number x # The x-axis coordinate of the world-space axis vector.
 ---@return number y # The y-axis coordinate of the world-space axis vector.
@@ -2078,11 +2855,17 @@ function WheelJoint:getAxis() end
 ---
 ---Returns the current joint translation speed.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/WheelJoint:getJointSpeed)
+---
 ---@return number speed # The translation speed of the joint in meters per second.
 function WheelJoint:getJointSpeed() end
 
 ---
 ---Returns the current joint translation.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/WheelJoint:getJointTranslation)
 ---
 ---@return number position # The translation of the joint in meters.
 function WheelJoint:getJointTranslation() end
@@ -2090,17 +2873,26 @@ function WheelJoint:getJointTranslation() end
 ---
 ---Returns the maximum motor torque.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/WheelJoint:getMaxMotorTorque)
+---
 ---@return number maxTorque # The maximum torque of the joint motor in newton meters.
 function WheelJoint:getMaxMotorTorque() end
 
 ---
 ---Returns the speed of the motor.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/WheelJoint:getMotorSpeed)
+---
 ---@return number speed # The speed of the joint motor in radians per second.
 function WheelJoint:getMotorSpeed() end
 
 ---
 ---Returns the current torque on the motor.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/WheelJoint:getMotorTorque)
 ---
 ---@param invdt number # How long the force applies. Usually the inverse time step or 1/dt.
 ---@return number torque # The torque on the motor in newton meters.
@@ -2109,11 +2901,17 @@ function WheelJoint:getMotorTorque(invdt) end
 ---
 ---Returns the damping ratio.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/WheelJoint:getSpringDampingRatio)
+---
 ---@return number ratio # The damping ratio.
 function WheelJoint:getSpringDampingRatio() end
 
 ---
 ---Returns the spring frequency.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/WheelJoint:getSpringFrequency)
 ---
 ---@return number freq # The frequency in hertz.
 function WheelJoint:getSpringFrequency() end
@@ -2121,11 +2919,17 @@ function WheelJoint:getSpringFrequency() end
 ---
 ---Checks if the joint motor is running.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/WheelJoint:isMotorEnabled)
+---
 ---@return boolean on # The status of the joint motor.
 function WheelJoint:isMotorEnabled() end
 
 ---
 ---Sets a new maximum motor torque.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/WheelJoint:setMaxMotorTorque)
 ---
 ---@param maxTorque number # The new maximum torque for the joint motor in newton meters.
 function WheelJoint:setMaxMotorTorque(maxTorque) end
@@ -2133,11 +2937,17 @@ function WheelJoint:setMaxMotorTorque(maxTorque) end
 ---
 ---Starts and stops the joint motor.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/WheelJoint:setMotorEnabled)
+---
 ---@param enable boolean # True turns the motor on and false turns it off.
 function WheelJoint:setMotorEnabled(enable) end
 
 ---
 ---Sets a new speed for the motor.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/WheelJoint:setMotorSpeed)
 ---
 ---@param speed number # The new speed for the joint motor in radians per second.
 function WheelJoint:setMotorSpeed(speed) end
@@ -2145,17 +2955,26 @@ function WheelJoint:setMotorSpeed(speed) end
 ---
 ---Sets a new damping ratio.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/WheelJoint:setSpringDampingRatio)
+---
 ---@param ratio number # The new damping ratio.
 function WheelJoint:setSpringDampingRatio(ratio) end
 
 ---
 ---Sets a new spring frequency.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/WheelJoint:setSpringFrequency)
+---
 ---@param freq number # The new frequency in hertz.
 function WheelJoint:setSpringFrequency(freq) end
 
 ---
 ---A world is an object that contains all bodies and joints.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.physics)
 ---
 ---@class love.World: love.Object
 local World = {}
@@ -2165,10 +2984,16 @@ local World = {}
 ---
 ---An error will occur if you attempt to use any of the destroyed objects after calling this function.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/World:destroy)
+---
 function World:destroy() end
 
 ---
 ---Returns a table with all bodies.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/World:getBodies)
 ---
 ---@return table bodies # A sequence with all bodies.
 function World:getBodies() end
@@ -2176,11 +3001,17 @@ function World:getBodies() end
 ---
 ---Returns the number of bodies in the world.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/World:getBodyCount)
+---
 ---@return number n # The number of bodies in the world.
 function World:getBodyCount() end
 
 ---
 ---Returns functions for the callbacks during the world update.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/World:getCallbacks)
 ---
 ---@return function beginContact # Gets called when two fixtures begin to overlap.
 ---@return function endContact # Gets called when two fixtures cease to overlap.
@@ -2191,11 +3022,17 @@ function World:getCallbacks() end
 ---
 ---Returns the number of contacts in the world.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/World:getContactCount)
+---
 ---@return number n # The number of contacts in the world.
 function World:getContactCount() end
 
 ---
 ---Returns the function for collision filtering.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/World:getContactFilter)
 ---
 ---@return function contactFilter # The function that handles the contact filtering.
 function World:getContactFilter() end
@@ -2203,11 +3040,17 @@ function World:getContactFilter() end
 ---
 ---Returns a table with all Contacts.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/World:getContacts)
+---
 ---@return table contacts # A sequence with all Contacts.
 function World:getContacts() end
 
 ---
 ---Get the gravity of the world.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/World:getGravity)
 ---
 ---@return number x # The x component of gravity.
 ---@return number y # The y component of gravity.
@@ -2216,17 +3059,26 @@ function World:getGravity() end
 ---
 ---Returns the number of joints in the world.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/World:getJointCount)
+---
 ---@return number n # The number of joints in the world.
 function World:getJointCount() end
 
 ---
 ---Returns a table with all joints.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/World:getJoints)
+---
 ---@return table joints # A sequence with all joints.
 function World:getJoints() end
 
 ---
 ---Gets whether the World is destroyed. Destroyed worlds cannot be used.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/World:isDestroyed)
 ---
 ---@return boolean destroyed # Whether the World is destroyed.
 function World:isDestroyed() end
@@ -2236,17 +3088,26 @@ function World:isDestroyed() end
 ---
 ---This will return true inside the callbacks from World:setCallbacks.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/World:isLocked)
+---
 ---@return boolean locked # Will be true if the world is in the process of updating its state.
 function World:isLocked() end
 
 ---
 ---Gets the sleep behaviour of the world.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/World:isSleepingAllowed)
+---
 ---@return boolean allow # True if bodies in the world are allowed to sleep, or false if not.
 function World:isSleepingAllowed() end
 
 ---
 ---Calls a function for each fixture inside the specified area by searching for any overlapping bounding box (Fixture:getBoundingBox).
+---
+---
+---[Open in Browser](https://love2d.org/wiki/World:queryBoundingBox)
 ---
 ---@param topLeftX number # The x position of the top-left point.
 ---@param topLeftY number # The y position of the top-left point.
@@ -2257,6 +3118,9 @@ function World:queryBoundingBox(topLeftX, topLeftY, bottomRightX, bottomRightY, 
 
 ---
 ---Casts a ray and calls a function for each fixtures it intersects. 
+---
+---
+---[Open in Browser](https://love2d.org/wiki/World:rayCast)
 ---
 ---@param fixture love.Fixture # The fixture intersecting the ray.
 ---@param x number # The x position of the intersection point.
@@ -2276,10 +3140,13 @@ function World:rayCast(fixture, x, y, xn, yn, fraction) end
 ---
 ---If you are interested to know when exactly each callback is called, consult a Box2d manual
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/World:setCallbacks)
+---
 ---@param beginContact function # Gets called when two fixtures begin to overlap.
 ---@param endContact function # Gets called when two fixtures cease to overlap. This will also be called outside of a world update, when colliding objects are destroyed.
----@param preSolve? function # Gets called before a collision gets resolved.
----@param postSolve? function # Gets called after the collision has been resolved.
+---@param preSolve function # Gets called before a collision gets resolved.
+---@param postSolve function # Gets called after the collision has been resolved.
 function World:setCallbacks(beginContact, endContact, preSolve, postSolve) end
 
 ---
@@ -2287,11 +3154,17 @@ function World:setCallbacks(beginContact, endContact, preSolve, postSolve) end
 ---
 ---If the group and category filtering doesn't generate a collision decision, this function gets called with the two fixtures as arguments. The function should return a boolean value where true means the fixtures will collide and false means they will pass through each other.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/World:setContactFilter)
+---
 ---@param filter function # The function handling the contact filtering.
 function World:setContactFilter(filter) end
 
 ---
 ---Set the gravity of the world.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/World:setGravity)
 ---
 ---@param x number # The x component of gravity.
 ---@param y number # The y component of gravity.
@@ -2300,11 +3173,17 @@ function World:setGravity(x, y) end
 ---
 ---Sets the sleep behaviour of the world.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/World:setSleepingAllowed)
+---
 ---@param allow boolean # True if bodies in the world are allowed to sleep, or false if not.
 function World:setSleepingAllowed(allow) end
 
 ---
 ---Translates the World's origin. Useful in large worlds where floating point precision issues become noticeable at far distances from the origin.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/World:translateOrigin)
 ---
 ---@param x number # The x component of the new origin with respect to the old origin.
 ---@param y number # The y component of the new origin with respect to the old origin.
@@ -2313,6 +3192,9 @@ function World:translateOrigin(x, y) end
 ---
 ---Update the state of the world.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/World:update)
+---
 ---@param dt number # The time (in seconds) to advance the physics simulation.
 ---@param velocityiterations? number # The maximum number of steps used to determine the new velocities when resolving a collision.
 ---@param positioniterations? number # The maximum number of steps used to determine the new positions when resolving a collision.
@@ -2320,6 +3202,9 @@ function World:update(dt, velocityiterations, positioniterations) end
 
 ---
 ---The types of a Body. 
+---
+---
+---[Open in Browser](https://love2d.org/wiki/BodyType)
 ---
 ---@alias love.BodyType
 ---
@@ -2337,6 +3222,9 @@ function World:update(dt, velocityiterations, positioniterations) end
 
 ---
 ---Different types of joints.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/JointType)
 ---
 ---@alias love.JointType
 ---
@@ -2378,6 +3266,9 @@ function World:update(dt, velocityiterations, positioniterations) end
 
 ---
 ---The different types of Shapes, as returned by Shape:getType.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/ShapeType)
 ---
 ---@alias love.ShapeType
 ---

--- a/meta/3rd/love2d/library/love/sound.lua
+++ b/meta/3rd/love2d/library/love/sound.lua
@@ -3,11 +3,17 @@
 ---
 ---This module is responsible for decoding sound files. It can't play the sounds, see love.audio for that.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.sound)
+---
 ---@class love.sound
 love.sound = {}
 
 ---
 ---Attempts to find a decoder for the encoded sound data in the specified file.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.sound.newDecoder)
 ---
 ---@overload fun(filename: string, buffer?: number):love.Decoder
 ---@param file love.File # The file with encoded sound data.
@@ -20,6 +26,9 @@ function love.sound.newDecoder(file, buffer) end
 ---
 ---The sound data will be decoded to the memory in a raw format. It is recommended to create only short sounds like effects, as a 3 minute song uses 30 MB of memory this way.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.sound.newSoundData)
+---
 ---@overload fun(file: love.File):love.SoundData
 ---@overload fun(decoder: love.Decoder):love.SoundData
 ---@overload fun(samples: number, rate?: number, bits?: number, channels?: number):love.SoundData
@@ -30,6 +39,9 @@ function love.sound.newSoundData(filename) end
 ---
 ---An object which can gradually decode a sound file.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.sound)
+---
 ---@class love.Decoder: love.Object
 local Decoder = {}
 
@@ -38,11 +50,17 @@ local Decoder = {}
 ---
 ---The new decoder will start decoding from the beginning of the audio stream.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Decoder:clone)
+---
 ---@return love.Decoder decoder # New copy of the decoder.
 function Decoder:clone() end
 
 ---
 ---Decodes the audio and returns a SoundData object containing the decoded audio data.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Decoder:decode)
 ---
 ---@return love.SoundData soundData # Decoded audio data.
 function Decoder:decode() end
@@ -50,11 +68,17 @@ function Decoder:decode() end
 ---
 ---Returns the number of bits per sample.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Decoder:getBitDepth)
+---
 ---@return number bitDepth # Either 8, or 16.
 function Decoder:getBitDepth() end
 
 ---
 ---Returns the number of channels in the stream.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Decoder:getChannelCount)
 ---
 ---@return number channels # 1 for mono, 2 for stereo.
 function Decoder:getChannelCount() end
@@ -62,17 +86,26 @@ function Decoder:getChannelCount() end
 ---
 ---Gets the duration of the sound file. It may not always be sample-accurate, and it may return -1 if the duration cannot be determined at all.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Decoder:getDuration)
+---
 ---@return number duration # The duration of the sound file in seconds, or -1 if it cannot be determined.
 function Decoder:getDuration() end
 
 ---
 ---Returns the sample rate of the Decoder.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Decoder:getSampleRate)
+---
 ---@return number rate # Number of samples per second.
 function Decoder:getSampleRate() end
 
 ---
 ---Sets the currently playing position of the Decoder.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Decoder:seek)
 ---
 ---@param offset number # The position to seek to, in seconds.
 function Decoder:seek(offset) end
@@ -82,11 +115,17 @@ function Decoder:seek(offset) end
 ---
 ---You can not play SoundData back directly. You must wrap a Source object around it.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.sound)
+---
 ---@class love.SoundData: love.Data, love.Object
 local SoundData = {}
 
 ---
 ---Returns the number of bits per sample.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/SoundData:getBitDepth)
 ---
 ---@return number bitdepth # Either 8, or 16.
 function SoundData:getBitDepth() end
@@ -94,17 +133,26 @@ function SoundData:getBitDepth() end
 ---
 ---Returns the number of channels in the SoundData.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/SoundData:getChannelCount)
+---
 ---@return number channels # 1 for mono, 2 for stereo.
 function SoundData:getChannelCount() end
 
 ---
 ---Gets the duration of the sound data.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/SoundData:getDuration)
+---
 ---@return number duration # The duration of the sound data in seconds.
 function SoundData:getDuration() end
 
 ---
 ---Gets the value of the sample-point at the specified position. For stereo SoundData objects, the data from the left and right channels are interleaved in that order.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/SoundData:getSample)
 ---
 ---@overload fun(self: love.SoundData, i: number, channel: number):number
 ---@param i number # An integer value specifying the position of the sample (starting at 0).
@@ -114,17 +162,26 @@ function SoundData:getSample(i) end
 ---
 ---Returns the number of samples per channel of the SoundData.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/SoundData:getSampleCount)
+---
 ---@return number count # Total number of samples.
 function SoundData:getSampleCount() end
 
 ---
 ---Returns the sample rate of the SoundData.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/SoundData:getSampleRate)
+---
 ---@return number rate # Number of samples per second.
 function SoundData:getSampleRate() end
 
 ---
 ---Sets the value of the sample-point at the specified position. For stereo SoundData objects, the data from the left and right channels are interleaved in that order.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/SoundData:setSample)
 ---
 ---@overload fun(self: love.SoundData, i: number, channel: number, sample: number)
 ---@param i number # An integer value specifying the position of the sample (starting at 0).

--- a/meta/3rd/love2d/library/love/system.lua
+++ b/meta/3rd/love2d/library/love/system.lua
@@ -3,11 +3,17 @@
 ---
 ---Provides access to information about the user's system.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.system)
+---
 ---@class love.system
 love.system = {}
 
 ---
 ---Gets text from the clipboard.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.system.getClipboardText)
 ---
 ---@return string text # The text currently held in the system's clipboard.
 function love.system.getClipboardText() end
@@ -15,11 +21,17 @@ function love.system.getClipboardText() end
 ---
 ---Gets the current operating system. In general, LÖVE abstracts away the need to know the current operating system, but there are a few cases where it can be useful (especially in combination with os.execute.)
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.system.getOS)
+---
 ---@return string osString # The current operating system. 'OS X', 'Windows', 'Linux', 'Android' or 'iOS'.
 function love.system.getOS() end
 
 ---
 ---Gets information about the system's power supply.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.system.getPowerInfo)
 ---
 ---@return love.PowerState state # The basic state of the power supply.
 ---@return number percent # Percentage of battery life left, between 0 and 100. nil if the value can't be determined or there's no battery.
@@ -29,6 +41,9 @@ function love.system.getPowerInfo() end
 ---
 ---Gets the amount of logical processor in the system.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.system.getProcessorCount)
+---
 ---@return number processorCount # Amount of logical processors.
 function love.system.getProcessorCount() end
 
@@ -37,11 +52,17 @@ function love.system.getProcessorCount() end
 ---
 ---Currently this is implemented on iOS and Android, and will always return false on other operating systems. The t.audio.mixwithsystem flag in love.conf can be used to configure whether background audio / music from other apps should play while LÖVE is open.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.system.hasBackgroundMusic)
+---
 ---@return boolean backgroundmusic # True if the user is playing music in the background via another app, false otherwise.
 function love.system.hasBackgroundMusic() end
 
 ---
 ---Opens a URL with the user's web or file browser.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.system.openURL)
 ---
 ---@param url string # The URL to open. Must be formatted as a proper URL.
 ---@return boolean success # Whether the URL was opened successfully.
@@ -50,17 +71,26 @@ function love.system.openURL(url) end
 ---
 ---Puts text in the clipboard.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.system.setClipboardText)
+---
 ---@param text string # The new text to hold in the system's clipboard.
 function love.system.setClipboardText(text) end
 
 ---
 ---Causes the device to vibrate, if possible. Currently this will only work on Android and iOS devices that have a built-in vibration motor.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.system.vibrate)
+---
 ---@param seconds? number # The duration to vibrate for. If called on an iOS device, it will always vibrate for 0.5 seconds due to limitations in the iOS system APIs.
 function love.system.vibrate(seconds) end
 
 ---
 ---The basic state of the system's power supply.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/PowerState)
 ---
 ---@alias love.PowerState
 ---

--- a/meta/3rd/love2d/library/love/thread.lua
+++ b/meta/3rd/love2d/library/love/thread.lua
@@ -9,11 +9,17 @@
 ---
 ---When a Thread is started, it only loads the love.thread module. Every other module has to be loaded with require.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.thread)
+---
 ---@class love.thread
 love.thread = {}
 
 ---
 ---Creates or retrieves a named thread channel.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.thread.getChannel)
 ---
 ---@param name string # The name of the channel you want to create or retrieve.
 ---@return love.Channel channel # The Channel object associated with the name.
@@ -24,11 +30,17 @@ function love.thread.getChannel(name) end
 ---
 ---One use for them is to pass new unnamed channels to other threads via Channel:push on a named channel.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.thread.newChannel)
+---
 ---@return love.Channel channel # The new Channel object.
 function love.thread.newChannel() end
 
 ---
 ---Creates a new Thread from a filename, string or FileData object containing Lua code.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.thread.newThread)
 ---
 ---@overload fun(fileData: love.FileData):love.Thread
 ---@overload fun(codestring: string):love.Thread
@@ -39,11 +51,17 @@ function love.thread.newThread(filename) end
 ---
 ---An object which can be used to send and receive data between different threads.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.thread)
+---
 ---@class love.Channel: love.Object
 local Channel = {}
 
 ---
 ---Clears all the messages in the Channel queue.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Channel:clear)
 ---
 function Channel:clear() end
 
@@ -52,6 +70,9 @@ function Channel:clear() end
 ---
 ---It waits until a message is in the queue then returns the message value.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Channel:demand)
+---
 ---@overload fun(self: love.Channel, timeout: number):any
 ---@return any value # The contents of the message.
 function Channel:demand() end
@@ -59,11 +80,17 @@ function Channel:demand() end
 ---
 ---Retrieves the number of messages in the thread Channel queue.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Channel:getCount)
+---
 ---@return number count # The number of messages in the queue.
 function Channel:getCount() end
 
 ---
 ---Gets whether a pushed value has been popped or otherwise removed from the Channel.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Channel:hasRead)
 ---
 ---@param id number # An id value previously returned by Channel:push.
 ---@return boolean hasread # Whether the value represented by the id has been removed from the Channel via Channel:pop, Channel:demand, or Channel:clear.
@@ -74,6 +101,9 @@ function Channel:hasRead(id) end
 ---
 ---It returns nil if there's no message in the queue.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Channel:peek)
+---
 ---@return any value # The contents of the message.
 function Channel:peek() end
 
@@ -83,6 +113,9 @@ function Channel:peek() end
 ---Calling multiple methods in a row on the same Channel is often useful. However if multiple Threads are calling this Channel's methods at the same time, the different calls on each Thread might end up interleaved (e.g. one or more of the second thread's calls may happen in between the first thread's calls.)
 ---
 ---This method avoids that issue by making sure the Thread calling the method has exclusive access to the Channel until the specified function has returned.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Channel:performAtomic)
 ---
 ---@param func function # The function to call, the form of function(channel, arg1, arg2, ...) end. The Channel is passed as the first argument to the function when it is called.
 ---@param arg1 any # Additional arguments that the given function will receive when it is called.
@@ -95,6 +128,9 @@ function Channel:performAtomic(func, arg1, ...) end
 ---
 ---It returns nil if there are no messages in the queue.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Channel:pop)
+---
 ---@return any value # The contents of the message.
 function Channel:pop() end
 
@@ -102,6 +138,9 @@ function Channel:pop() end
 ---Send a message to the thread Channel.
 ---
 ---See Variant for the list of supported types.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Channel:push)
 ---
 ---@param value any # The contents of the message.
 ---@return number id # Identifier which can be supplied to Channel:hasRead
@@ -112,6 +151,9 @@ function Channel:push(value) end
 ---
 ---See Variant for the list of supported types.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Channel:supply)
+---
 ---@overload fun(self: love.Channel, value: any, timeout: number):boolean
 ---@param value any # The contents of the message.
 ---@return boolean success # Whether the message was successfully supplied (always true).
@@ -120,11 +162,17 @@ function Channel:supply(value) end
 ---
 ---A Thread is a chunk of code that can run in parallel with other threads. Data can be sent between different threads with Channel objects.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.thread)
+---
 ---@class love.Thread: love.Object
 local Thread = {}
 
 ---
 ---Retrieves the error string from the thread if it produced an error.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Thread:getError)
 ---
 ---@return string err # The error message, or nil if the Thread has not caused an error.
 function Thread:getError() end
@@ -134,6 +182,9 @@ function Thread:getError() end
 ---
 ---Threads which are not running can be (re)started with Thread:start.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Thread:isRunning)
+---
 ---@return boolean value # True if the thread is running, false otherwise.
 function Thread:isRunning() end
 
@@ -142,6 +193,9 @@ function Thread:isRunning() end
 ---
 ---Beginning with version 0.9.0, threads can be restarted after they have completed their execution.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/Thread:start)
+---
 ---@overload fun(self: love.Thread, arg1: any, arg2: any, ...)
 function Thread:start() end
 
@@ -149,5 +203,8 @@ function Thread:start() end
 ---Wait for a thread to finish.
 ---
 ---This call will block until the thread finishes.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/Thread:wait)
 ---
 function Thread:wait() end

--- a/meta/3rd/love2d/library/love/timer.lua
+++ b/meta/3rd/love2d/library/love/timer.lua
@@ -3,11 +3,17 @@
 ---
 ---Provides an interface to the user's clock.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.timer)
+---
 ---@class love.timer
 love.timer = {}
 
 ---
 ---Returns the average delta time (seconds per frame) over the last second.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.timer.getAverageDelta)
 ---
 ---@return number delta # The average delta time over the last second.
 function love.timer.getAverageDelta() end
@@ -15,11 +21,17 @@ function love.timer.getAverageDelta() end
 ---
 ---Returns the time between the last two frames.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.timer.getDelta)
+---
 ---@return number dt # The time passed (in seconds).
 function love.timer.getDelta() end
 
 ---
 ---Returns the current frames per second.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.timer.getFPS)
 ---
 ---@return number fps # The current FPS.
 function love.timer.getFPS() end
@@ -29,11 +41,17 @@ function love.timer.getFPS() end
 ---
 ---This function should only be used to calculate differences between points in time, as the starting time of the timer is unknown.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.timer.getTime)
+---
 ---@return number time # The time in seconds. Given as a decimal, accurate to the microsecond.
 function love.timer.getTime() end
 
 ---
 ---Pauses the current thread for the specified amount of time.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.timer.sleep)
 ---
 ---@param s number # Seconds to sleep for.
 function love.timer.sleep(s) end
@@ -42,6 +60,9 @@ function love.timer.sleep(s) end
 ---Measures the time between two frames.
 ---
 ---Calling this changes the return value of love.timer.getDelta.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.timer.step)
 ---
 ---@return number dt # The time passed (in seconds).
 function love.timer.step() end

--- a/meta/3rd/love2d/library/love/touch.lua
+++ b/meta/3rd/love2d/library/love/touch.lua
@@ -3,11 +3,17 @@
 ---
 ---Provides an interface to touch-screen presses.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.touch)
+---
 ---@class love.touch
 love.touch = {}
 
 ---
 ---Gets the current position of the specified touch-press, in pixels.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.touch.getPosition)
 ---
 ---@param id lightuserdata # The identifier of the touch-press. Use love.touch.getTouches, love.touchpressed, or love.touchmoved to obtain touch id values.
 ---@return number x # The position along the x-axis of the touch-press inside the window, in pixels.
@@ -17,12 +23,18 @@ function love.touch.getPosition(id) end
 ---
 ---Gets the current pressure of the specified touch-press.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.touch.getPressure)
+---
 ---@param id lightuserdata # The identifier of the touch-press. Use love.touch.getTouches, love.touchpressed, or love.touchmoved to obtain touch id values.
 ---@return number pressure # The pressure of the touch-press. Most touch screens aren't pressure sensitive, in which case the pressure will be 1.
 function love.touch.getPressure(id) end
 
 ---
 ---Gets a list of all active touch-presses.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.touch.getTouches)
 ---
 ---@return table touches # A list of active touch-press id values, which can be used with love.touch.getPosition.
 function love.touch.getTouches() end

--- a/meta/3rd/love2d/library/love/video.lua
+++ b/meta/3rd/love2d/library/love/video.lua
@@ -5,11 +5,17 @@
 ---
 ---It can't draw the videos, see love.graphics.newVideo and Video objects for that.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.video)
+---
 ---@class love.video
 love.video = {}
 
 ---
 ---Creates a new VideoStream. Currently only Ogg Theora video files are supported. VideoStreams can't draw videos, see love.graphics.newVideo for that.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.video.newVideoStream)
 ---
 ---@overload fun(file: love.File):love.VideoStream
 ---@param filename string # The file path to the Ogg Theora video file.
@@ -19,11 +25,17 @@ function love.video.newVideoStream(filename) end
 ---
 ---An object which decodes, streams, and controls Videos.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.video)
+---
 ---@class love.VideoStream: love.Object
 local VideoStream = {}
 
 ---
 ---Gets the filename of the VideoStream.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/VideoStream:getFilename)
 ---
 ---@return string filename # The filename of the VideoStream
 function VideoStream:getFilename() end
@@ -31,32 +43,50 @@ function VideoStream:getFilename() end
 ---
 ---Gets whether the VideoStream is playing.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/VideoStream:isPlaying)
+---
 ---@return boolean playing # Whether the VideoStream is playing.
 function VideoStream:isPlaying() end
 
 ---
 ---Pauses the VideoStream.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/VideoStream:pause)
+---
 function VideoStream:pause() end
 
 ---
 ---Plays the VideoStream.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/VideoStream:play)
 ---
 function VideoStream:play() end
 
 ---
 ---Rewinds the VideoStream. Synonym to VideoStream:seek(0).
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/VideoStream:rewind)
+---
 function VideoStream:rewind() end
 
 ---
 ---Sets the current playback position of the VideoStream.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/VideoStream:seek)
 ---
 ---@param offset number # The time in seconds since the beginning of the VideoStream.
 function VideoStream:seek(offset) end
 
 ---
 ---Gets the current playback position of the VideoStream.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/VideoStream:tell)
 ---
 ---@return number seconds # The number of seconds sionce the beginning of the VideoStream.
 function VideoStream:tell() end

--- a/meta/3rd/love2d/library/love/window.lua
+++ b/meta/3rd/love2d/library/love/window.lua
@@ -3,11 +3,17 @@
 ---
 ---Provides an interface for modifying and retrieving information about the program's window.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window)
+---
 ---@class love.window
 love.window = {}
 
 ---
 ---Closes the window. It can be reopened with love.window.setMode.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.close)
 ---
 function love.window.close() end
 
@@ -19,6 +25,9 @@ function love.window.close() end
 ---This function converts coordinates from pixels to the size users are expecting them to display at onscreen. love.window.toPixels does the opposite. The highdpi window flag must be enabled to use the full pixel density of a Retina screen on Mac OS X and iOS. The flag currently does nothing on Windows and Linux, and on Android it is effectively always enabled.
 ---
 ---Most LÖVE functions return values and expect arguments in terms of pixels rather than density-independent units.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.fromPixels)
 ---
 ---@overload fun(px: number, py: number):number, number
 ---@param pixelvalue number # A number in pixels to convert to density-independent units.
@@ -34,11 +43,17 @@ function love.window.fromPixels(pixelvalue) end
 ---
 ---The highdpi window flag must be enabled to use the full pixel density of a Retina screen on Mac OS X and iOS. The flag currently does nothing on Windows and Linux, and on Android it is effectively always enabled.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.getDPIScale)
+---
 ---@return number scale # The pixel scale factor associated with the window.
 function love.window.getDPIScale() end
 
 ---
 ---Gets the width and height of the desktop.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.getDesktopDimensions)
 ---
 ---@param displayindex? number # The index of the display, if multiple monitors are available.
 ---@return string width # The width of the desktop.
@@ -48,11 +63,17 @@ function love.window.getDesktopDimensions(displayindex) end
 ---
 ---Gets the number of connected monitors.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.getDisplayCount)
+---
 ---@return number count # The number of currently connected displays.
 function love.window.getDisplayCount() end
 
 ---
 ---Gets the name of a display.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.getDisplayName)
 ---
 ---@param displayindex? number # The index of the display to get the name of.
 ---@return string name # The name of the specified display.
@@ -61,12 +82,18 @@ function love.window.getDisplayName(displayindex) end
 ---
 ---Gets current device display orientation.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.getDisplayOrientation)
+---
 ---@param displayindex? number # Display index to get its display orientation, or nil for default display index.
 ---@return love.DisplayOrientation orientation # Current device display orientation.
 function love.window.getDisplayOrientation(displayindex) end
 
 ---
 ---Gets whether the window is fullscreen.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.getFullscreen)
 ---
 ---@return boolean fullscreen # True if the window is fullscreen, false otherwise.
 ---@return love.FullscreenType fstype # The type of fullscreen mode used.
@@ -75,6 +102,9 @@ function love.window.getFullscreen() end
 ---
 ---Gets a list of supported fullscreen modes.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.getFullscreenModes)
+---
 ---@param displayindex? number # The index of the display, if multiple monitors are available.
 ---@return table modes # A table of width/height pairs. (Note that this may not be in order.)
 function love.window.getFullscreenModes(displayindex) end
@@ -82,11 +112,17 @@ function love.window.getFullscreenModes(displayindex) end
 ---
 ---Gets the window icon.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.getIcon)
+---
 ---@return love.ImageData imagedata # The window icon imagedata, or nil if no icon has been set with love.window.setIcon.
 function love.window.getIcon() end
 
 ---
 ---Gets the display mode and properties of the window.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.getMode)
 ---
 ---@return number width # Window width.
 ---@return number height # Window height.
@@ -98,6 +134,9 @@ function love.window.getMode() end
 ---
 ---The window position is in the coordinate space of the display it is currently in.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.getPosition)
+---
 ---@return number x # The x-coordinate of the window's position.
 ---@return number y # The y-coordinate of the window's position.
 ---@return number displayindex # The index of the display that the window is in.
@@ -105,6 +144,9 @@ function love.window.getPosition() end
 
 ---
 ---Gets area inside the window which is known to be unobstructed by a system title bar, the iPhone X notch, etc. Useful for making sure UI elements can be seen by the user.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.getSafeArea)
 ---
 ---@return number x # Starting position of safe area (x-axis).
 ---@return number y # Starting position of safe area (y-axis).
@@ -115,11 +157,17 @@ function love.window.getSafeArea() end
 ---
 ---Gets the window title.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.getTitle)
+---
 ---@return string title # The current window title.
 function love.window.getTitle() end
 
 ---
 ---Gets current vertical synchronization (vsync).
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.getVSync)
 ---
 ---@return number vsync # Current vsync status. 1 if enabled, 0 if disabled, and -1 for adaptive vsync.
 function love.window.getVSync() end
@@ -127,11 +175,17 @@ function love.window.getVSync() end
 ---
 ---Checks if the game window has keyboard focus.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.hasFocus)
+---
 ---@return boolean focus # True if the window has the focus or false if not.
 function love.window.hasFocus() end
 
 ---
 ---Checks if the game window has mouse focus.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.hasMouseFocus)
 ---
 ---@return boolean focus # True if the window has mouse focus or false if not.
 function love.window.hasMouseFocus() end
@@ -141,6 +195,9 @@ function love.window.hasMouseFocus() end
 ---
 ---Display sleep is disabled by default. Some types of input (e.g. joystick button presses) might not prevent the display from sleeping, if display sleep is allowed.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.isDisplaySleepEnabled)
+---
 ---@return boolean enabled # True if system display sleep is enabled / allowed, false otherwise.
 function love.window.isDisplaySleepEnabled() end
 
@@ -149,17 +206,26 @@ function love.window.isDisplaySleepEnabled() end
 ---
 ---The window can be maximized if it is not fullscreen and is resizable, and either the user has pressed the window's Maximize button or love.window.maximize has been called.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.isMaximized)
+---
 ---@return boolean maximized # True if the window is currently maximized in windowed mode, false otherwise.
 function love.window.isMaximized() end
 
 ---
 ---Gets whether the Window is currently minimized.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.isMinimized)
+---
 ---@return boolean minimized # True if the window is currently minimized, false otherwise.
 function love.window.isMinimized() end
 
 ---
 ---Checks if the window is open.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.isOpen)
 ---
 ---@return boolean open # True if the window is open, false otherwise.
 function love.window.isOpen() end
@@ -169,6 +235,9 @@ function love.window.isOpen() end
 ---
 ---The window is considered visible if it's not minimized and the program isn't hidden.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.isVisible)
+---
 ---@return boolean visible # True if the window is visible or false if not.
 function love.window.isVisible() end
 
@@ -177,10 +246,16 @@ function love.window.isVisible() end
 ---
 ---This function has no effect if the window isn't resizable, since it essentially programmatically presses the window's 'maximize' button.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.maximize)
+---
 function love.window.maximize() end
 
 ---
 ---Minimizes the window to the system's task bar / dock.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.minimize)
 ---
 function love.window.minimize() end
 
@@ -189,11 +264,17 @@ function love.window.minimize() end
 ---
 ---In Windows the taskbar icon will flash, and in OS X the dock icon will bounce.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.requestAttention)
+---
 ---@param continuous? boolean # Whether to continuously request attention until the window becomes active, or to do it only once.
 function love.window.requestAttention(continuous) end
 
 ---
 ---Restores the size and position of the window if it was minimized or maximized.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.restore)
 ---
 function love.window.restore() end
 
@@ -202,11 +283,17 @@ function love.window.restore() end
 ---
 ---Display sleep is disabled by default. Some types of input (e.g. joystick button presses) might not prevent the display from sleeping, if display sleep is allowed.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.setDisplaySleepEnabled)
+---
 ---@param enable boolean # True to enable system display sleep, false to disable it.
 function love.window.setDisplaySleepEnabled(enable) end
 
 ---
 ---Enters or exits fullscreen. The display to use when entering fullscreen is chosen based on which display the window is currently in, if multiple monitors are connected.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.setFullscreen)
 ---
 ---@overload fun(fullscreen: boolean, fstype: love.FullscreenType):boolean
 ---@param fullscreen boolean # Whether to enter or exit fullscreen mode.
@@ -215,6 +302,9 @@ function love.window.setFullscreen(fullscreen) end
 
 ---
 ---Sets the window icon until the game is quit. Not all operating systems support very large icon images.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.setIcon)
 ---
 ---@param imagedata love.ImageData # The window icon image.
 ---@return boolean success # Whether the icon has been set successfully.
@@ -227,6 +317,9 @@ function love.window.setIcon(imagedata) end
 ---
 ---Changing the display mode may have side effects: for example, canvases will be cleared and values sent to shaders with canvases beforehand or re-draw to them afterward if you need to.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.setMode)
+---
 ---@param width number # Display width.
 ---@param height number # Display height.
 ---@param flags? {fullscreen: boolean, fullscreentype: love.FullscreenType, vsync: boolean, msaa: number, stencil: boolean, depth: number, resizable: boolean, borderless: boolean, centered: boolean, display: number, minwidth: number, minheight: number, highdpi: boolean, x: number, y: number, usedpiscale: boolean, srgb: boolean} # The flags table with the options:
@@ -238,6 +331,9 @@ function love.window.setMode(width, height, flags) end
 ---
 ---The window position is in the coordinate space of the specified display.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.setPosition)
+---
 ---@param x number # The x-coordinate of the window's position.
 ---@param y number # The y-coordinate of the window's position.
 ---@param displayindex? number # The index of the display that the new window position is relative to.
@@ -246,17 +342,26 @@ function love.window.setPosition(x, y, displayindex) end
 ---
 ---Sets the window title.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.setTitle)
+---
 ---@param title string # The new window title.
 function love.window.setTitle(title) end
 
 ---
 ---Sets vertical synchronization mode.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.setVSync)
+---
 ---@param vsync number # VSync number: 1 to enable, 0 to disable, and -1 for adaptive vsync.
 function love.window.setVSync(vsync) end
 
 ---
 ---Displays a message box dialog above the love window. The message box contains a title, optional text, and buttons.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.showMessageBox)
 ---
 ---@overload fun(title: string, message: string, buttonlist: table, type?: love.MessageBoxType, attachtowindow?: boolean):number
 ---@param title string # The title of the message box.
@@ -275,6 +380,9 @@ function love.window.showMessageBox(title, message, type, attachtowindow) end
 ---
 ---Most LÖVE functions return values and expect arguments in terms of pixels rather than density-independent units.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.toPixels)
+---
 ---@overload fun(x: number, y: number):number, number
 ---@param value number # A number in density-independent units to convert to pixels.
 ---@return number pixelvalue # The converted number, in pixels.
@@ -287,6 +395,9 @@ function love.window.toPixels(value) end
 ---
 ---Changing the display mode may have side effects: for example, canvases will be cleared. Make sure to save the contents of canvases beforehand or re-draw to them afterward if you need to.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/love.window.updateMode)
+---
 ---@param width number # Window width.
 ---@param height number # Window height.
 ---@param settings {fullscreen: boolean, fullscreentype: love.FullscreenType, vsync: boolean, msaa: number, resizable: boolean, borderless: boolean, centered: boolean, display: number, minwidth: number, minheight: number, highdpi: boolean, x: number, y: number} # The settings table with the following optional fields. Any field not filled in will use the current value that would be returned by love.window.getMode.
@@ -295,6 +406,9 @@ function love.window.updateMode(width, height, settings) end
 
 ---
 ---Types of device display orientation.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/DisplayOrientation)
 ---
 ---@alias love.DisplayOrientation
 ---
@@ -321,6 +435,9 @@ function love.window.updateMode(width, height, settings) end
 ---
 ---Types of fullscreen modes.
 ---
+---
+---[Open in Browser](https://love2d.org/wiki/FullscreenType)
+---
 ---@alias love.FullscreenType
 ---
 ---Sometimes known as borderless fullscreen windowed mode. A borderless screen-sized window is created which sits on top of all desktop UI elements. The window is automatically resized to match the dimensions of the desktop, and its size cannot be changed.
@@ -337,6 +454,9 @@ function love.window.updateMode(width, height, settings) end
 
 ---
 ---Types of message box dialogs. Different types may have slightly different looks.
+---
+---
+---[Open in Browser](https://love2d.org/wiki/MessageBoxType)
 ---
 ---@alias love.MessageBoxType
 ---

--- a/tools/love-api.lua
+++ b/tools/love-api.lua
@@ -101,7 +101,11 @@ local function buildMD(desc)
                :gsub('%.  ', '.\n---\n---')
 end
 
-local function buildDescription(desc, notes)
+---@param desc any
+---@param notes any
+---@param wikiPage string?
+---@return string
+local function buildDescription(desc, notes, wikiPage)
     local lines = {}
     if desc then
         lines[#lines+1] = '---'
@@ -112,6 +116,11 @@ local function buildDescription(desc, notes)
         lines[#lines+1] = '---'
         lines[#lines+1] = '---### NOTE:'
         lines[#lines+1] = '---' .. buildMD(notes)
+        lines[#lines+1] = '---'
+    end
+    if wikiPage then
+        lines[#lines+1] = '---'
+        lines[#lines+1] = ("---[Open in Browser](https://love2d.org/wiki/%s)"):format(wikiPage)
         lines[#lines+1] = '---'
     end
     return table.concat(lines, '\n')
@@ -153,7 +162,7 @@ end
 
 local function buildFunction(func, node, typeName)
     local text = {}
-    text[#text+1] = buildDescription(func.description, func.notes)
+    text[#text+1] = buildDescription(func.description, func.notes, node..func.name)
     for i = 2, #func.variants do
         local variant = func.variants[i]
         text[#text+1] = ('---@overload %s'):format(buildDocFunc(variant, typeName))
@@ -204,7 +213,7 @@ local function buildFile(class, defs)
     if defs.version then
         text[#text+1] = ('-- version: %s'):format(defs.version)
     end
-    text[#text+1] = buildDescription(defs.description, defs.notes)
+    text[#text+1] = buildDescription(defs.description, defs.notes, class)
     text[#text+1] = ('---@class %s'):format(class)
     text[#text+1] = ('%s = {}'):format(class)
 
@@ -216,7 +225,7 @@ local function buildFile(class, defs)
     for _, tp in ipairs(defs.types or {}) do
         local mark = {}
         text[#text+1] = ''
-        text[#text+1] = buildDescription(tp.description, tp.notes)
+        text[#text+1] = buildDescription(tp.description, tp.notes, class)
         text[#text+1] = ('---@class %s%s'):format(getTypeName(tp.name), buildSuper(tp))
         text[#text+1] = ('local %s = {}'):format(tp.name)
         for _, func in ipairs(tp.functions or {}) do
@@ -236,7 +245,7 @@ local function buildFile(class, defs)
 
     for _, enum in ipairs(defs.enums or {}) do
         text[#text+1] = ''
-        text[#text+1] = buildDescription(enum.description, enum.notes)
+        text[#text+1] = buildDescription(enum.description, enum.notes, enum.name)
         text[#text+1] = ('---@alias %s'):format(getTypeName(enum.name))
         for _, constant in ipairs(enum.constants) do
             text[#text+1] = buildDescription(constant.description, constant.notes)


### PR DESCRIPTION
I have added links to from any entity to the wiki, thanks to love2ds naming scheme. I haven't tested all links, however it worked with a class, function and even enums. The big advantage over [LOVE's shortcut](https://marketplace.visualstudio.com/items?itemName=bschulte.love) is that it also works on objects