### PR TITLE
ci: use ubuntu docker container to build linux releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,14 +20,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { os: ubuntu-20.04,   target: linux,   platform: linux-x64    }
-          - { os: ubuntu-20.04,   target: linux,   platform: linux-arm64  }
+          - { os: ubuntu-20.04,   target: linux,   platform: linux-x64,   container: 'ubuntu:18.04' }
+          - { os: ubuntu-20.04,   target: linux,   platform: linux-arm64, container: 'ubuntu:18.04' }
           - { os: macos-11,       target: darwin,  platform: darwin-x64   }
           - { os: macos-11,       target: darwin,  platform: darwin-arm64 }
           - { os: windows-latest, target: windows, platform: win32-ia32   }
           - { os: windows-latest, target: windows, platform: win32-x64    }
     runs-on: ${{ matrix.os }}
+    container:
+      image: ${{ matrix.container }}
     steps:
+      - name: Prepare container
+        if: ${{ matrix.target == 'linux' }}
+        run: |
+          apt-get update
+          apt-get install -y software-properties-common
+          add-apt-repository -y ppa:ubuntu-toolchain-r/test # For gcc-9 and g++-9
+          add-apt-repository -y ppa:git-core/ppa # For git>=2.18.
+          apt-get update
+          apt-get install -y sudo git gcc-9 g++-9
+
       - name: Install aarch64-linux-gnu
         if: ${{ matrix.platform == 'linux-arm64' }}
         run: |


### PR DESCRIPTION
Switch back to Ubuntu 18.04 for building linux releases. This allows for running these on older systems that do not provide GLIBC_2.29.

fix #1828