### PR TITLE
Add configuration value for what auto-require adds

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@
 * `FIX` Prevent class methods from triggering missing-fields diagnostics
 * `ADD` missing locale
 * `FIX` updates the EmmyLuaCodeStyle submodule reference to a newer commit, ensuring compatibility with GCC 15
+* `NEW` Setting: `Lua.completion.requireFunction`: What the auto-require completion should add (e.g. `import` instead of `require`)
 
 ## 3.14.0
 `2025-4-7`

--- a/doc/en-us/config.md
+++ b/doc/en-us/config.md
@@ -148,6 +148,22 @@ string
 "@"
 ```
 
+# completion.requireFunction
+
+The function to insert when an auto-require is triggered.
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+"require"
+```
+
 # completion.requireSeparator
 
 The separator used when `require`.

--- a/doc/pt-br/config.md
+++ b/doc/pt-br/config.md
@@ -148,6 +148,22 @@ string
 "@"
 ```
 
+# completion.requireFunction
+
+The function to insert when an auto-require is triggered.
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+"require"
+```
+
 # completion.requireSeparator
 
 The separator used when `require`.

--- a/doc/zh-cn/config.md
+++ b/doc/zh-cn/config.md
@@ -148,6 +148,22 @@ string
 "@"
 ```
 
+# completion.requireFunction
+
+The function to insert when an auto-require is triggered.
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+"require"
+```
+
 # completion.requireSeparator
 
 `require` 时使用的分隔符。

--- a/doc/zh-tw/config.md
+++ b/doc/zh-tw/config.md
@@ -148,6 +148,22 @@ string
 "@"
 ```
 
+# completion.requireFunction
+
+The function to insert when an auto-require is triggered.
+
+## type
+
+```ts
+string
+```
+
+## default
+
+```jsonc
+"require"
+```
+
 # completion.requireSeparator
 
 `require` 時使用的分隔符。

--- a/locale/en-us/setting.lua
+++ b/locale/en-us/setting.lua
@@ -180,6 +180,8 @@ config.completion.autoRequire            =
 "When the input looks like a file name, automatically `require` this file."
 config.completion.showParams             =
 "Display parameters in completion list. When the function has multiple definitions, they will be displayed separately."
+config.completion.requireFunction        =
+"The function to insert when an auto-require is triggered."
 config.completion.requireSeparator       =
 "The separator used when `require`."
 config.completion.postfix                =

--- a/locale/es-419/setting.lua
+++ b/locale/es-419/setting.lua
@@ -182,6 +182,8 @@ config.completion.autoRequire            =
 "Agrega automáticamente el `require` correspondiente cuando la entrada se parece a un nombre de archivo."
 config.completion.showParams             =
 "Muestra los parámetros en la lista de completado. Cuando la función tiene múltiples definiciones, se mostrarán por separado."
+config.completion.requireFunction        = -- TODO: need translate!
+"The function to insert when an auto-require is triggered."
 config.completion.requireSeparator       =
 "Separador usado en `require`."
 config.completion.postfix                =

--- a/locale/ja-jp/setting.lua
+++ b/locale/ja-jp/setting.lua
@@ -180,6 +180,8 @@ config.completion.autoRequire            = -- TODO: need translate!
 "When the input looks like a file name, automatically `require` this file."
 config.completion.showParams             = -- TODO: need translate!
 "Display parameters in completion list. When the function has multiple definitions, they will be displayed separately."
+config.completion.requireFunction        = -- TODO: need translate!
+"The function to insert when an auto-require is triggered."
 config.completion.requireSeparator       = -- TODO: need translate!
 "The separator used when `require`."
 config.completion.postfix                = -- TODO: need translate!

--- a/locale/pt-br/setting.lua
+++ b/locale/pt-br/setting.lua
@@ -180,6 +180,8 @@ config.completion.autoRequire            = -- TODO: need translate!
 "When the input looks like a file name, automatically `require` this file."
 config.completion.showParams             = -- TODO: need translate!
 "Display parameters in completion list. When the function has multiple definitions, they will be displayed separately."
+config.completion.requireFunction        = -- TODO: need translate!
+"The function to insert when an auto-require is triggered."
 config.completion.requireSeparator       = -- TODO: need translate!
 "The separator used when `require`."
 config.completion.postfix                = -- TODO: need translate!

--- a/locale/zh-cn/setting.lua
+++ b/locale/zh-cn/setting.lua
@@ -179,6 +179,8 @@ config.completion.autoRequire            =
 "输入内容看起来是个文件名时，自动 `require` 此文件。"
 config.completion.showParams             =
 "在建议列表中显示函数的参数信息，函数拥有多个定义时会分开显示。"
+config.completion.requireFunction        = -- TODO: need translate!
+"The function to insert when an auto-require is triggered."
 config.completion.requireSeparator       =
 "`require` 时使用的分隔符。"
 config.completion.postfix                =

--- a/locale/zh-tw/setting.lua
+++ b/locale/zh-tw/setting.lua
@@ -179,6 +179,8 @@ config.completion.autoRequire            =
 "輸入內容看起來是個檔名時，自動 `require` 此檔案。"
 config.completion.showParams             =
 "在建議列表中顯示函式的參數資訊，函式擁有多個定義時會分開顯示。"
+config.completion.requireFunction        = -- TODO: need translate!
+"The function to insert when an auto-require is triggered."
 config.completion.requireSeparator       =
 "`require` 時使用的分隔符。"
 config.completion.postfix                =

--- a/script/config/template.lua
+++ b/script/config/template.lua
@@ -346,6 +346,7 @@ local template = {
                                             },
     ['Lua.completion.autoRequire']          = Type.Boolean >> true,
     ['Lua.completion.showParams']           = Type.Boolean >> true,
+    ['Lua.completion.requireFunction']      = Type.String  >> 'require',
     ['Lua.completion.requireSeparator']     = Type.String  >> '.',
     ['Lua.completion.postfix']              = Type.String  >> '@',
     ['Lua.signatureHelp.enable']            = Type.Boolean >> true,

--- a/script/core/command/autoRequire.lua
+++ b/script/core/command/autoRequire.lua
@@ -4,6 +4,7 @@ local rpath  = require 'workspace.require-path'
 local client = require 'client'
 local lang   = require 'language'
 local guide  = require 'parser.guide'
+local config = require 'config'
 
 local function inComment(state, pos)
     for _, comm in ipairs(state.comms) do
@@ -119,7 +120,8 @@ local function applyAutoRequire(uri, row, name, result, fmt, fullKeyPath)
     if fmt.col and fmt.col > #text then
         sp = (' '):rep(fmt.col - #text - 1)
     end
-    text = ('local %s%s= require%s%s\n'):format(name, sp, quotedResult, fullKeyPath)
+    local requireName = config.get(uri, "Lua.completion.requireFunction")
+    text = ('local %s%s= %s%s%s\n'):format(name, sp, requireName, quotedResult, fullKeyPath)
     client.editText(uri, {
         {
             start  = guide.positionOf(row, 0),


### PR DESCRIPTION
Auto-require always adds the `require` function specifically. However, it's common in projects to have their own special `require` functions, like `import` or `include` -- so this PR adds a configuration option which lets you change what it imports.

`Lua.completion.requireFunction` defaults to `"require"`. I think I did this right?

This is open as a draft because I'm unable to test this -- I don't fully understand the environment or how to debug this project. If someone could test this, it'd be great. (The built exe did nothing when ran, unlike the exe included in VSCode... not really sure what's happening there.)