### PR TITLE
fix: typed `@field` should not override other defined field

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `FIX` Typed `@field` (eg `---@field [string] boolean`) should not override other defined field [#2171](https://github.com/LuaLS/lua-language-server/issues/2171), [#2711](https://github.com/LuaLS/lua-language-server/issues/2711)
 
 ## 3.15.0
 `2025-6-25`

--- a/test/type_inference/common.lua
+++ b/test/type_inference/common.lua
@@ -3608,6 +3608,25 @@ local t
 local <?x?> = t.n
 ]]
 
+TEST 'function' [[
+---@class A
+---@field [string] boolean
+local t
+function t.f() end
+
+local <?f?> = t.f
+]]
+
+TEST 'function' [[
+---@class A
+---@field [string] boolean
+local t = {
+    f = function () end
+}
+
+local <?f?> = t.f
+]]
+
 TEST 'string' [[
 ---@class string
 ---@operator mod: string


### PR DESCRIPTION
fixes #2171, fixes #2711

## The problem
I found these issues while discussing in #3221.
In short, the typed `@field [T1] T2` should only apply when no types found for that specific key.
I found a fix after some debugging, implementation details: https://github.com/LuaLS/lua-language-server/discussions/3221#discussioncomment-13669060


### before
```lua
---@class A
---@field [string] boolean
local A
function A:f() end

local a = A.a   --> boolean ✅
local f = A.f   --> boolean|function ❌
```

### after
```lua
---@class A
---@field [string] boolean
local A
function A:f() end

local a = A.a   --> boolean ✅
local f = A.f   --> function ✅
```

## 中文版

`@field [T1] T2` 似應該只在對應 key 找不到任何 type define 時才 apply
解決方式是簡單將相關 infer logic 延後到查找完 class variable 的 `setfield/setmethod` 之後才處理