### PR TITLE
feat: support per library ignoreDir when library path prefix matched

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
+* `NEW` Support per library settings in ignoreDir
+```jsonc
+{
+  "workspace.library": [ "/path/to/lib", "/path/to/lib2" ],
+  "workspace.ignoreDir": [
+    "/path/to/lib/**/lib-ignore", // extracted pattern will be "/**/lib-ignore" and only applies to "/path/to/lib"
+    "global-ignore" // this will still apply to all of "/path/to/lib", "/path/to/lib2", current workspace
+  ]
+}
+```
 
 ## 3.15.0
 `2025-6-25`

--- a/script/workspace/workspace.lua
+++ b/script/workspace/workspace.lua
@@ -216,9 +216,31 @@ function m.getLibraryMatchers(scp)
             pattern[#pattern+1] = path
         end
     end
+    local libPatterns = {}
     for _, path in ipairs(config.get(scp.uri, 'Lua.workspace.ignoreDir')) do
         log.debug('Ignore directory:', path)
-        pattern[#pattern+1] = path
+        -- check for library specific ignoreDir
+        local isLibPattern = false
+        local nPath = files.normalize(path)
+        for _, libPath in ipairs(config.get(scp.uri, 'Lua.workspace.library')) do
+            -- check if ignoreDir path is relative to libPath
+            local nLibPath = m.getAbsolutePath(scp.uri, libPath)
+            if nLibPath then
+                local relativeToLibPath = fs.relative(fs.path(nPath), fs.path(nLibPath)):string()
+                if relativeToLibPath ~= ''  -- will be empty string on windows if drive letter is different
+                and relativeToLibPath:sub(1, 2) ~= '..' -- a valid subpath of libPath should not starts with `..`
+                then
+                    isLibPattern = true
+                    -- add leading `/` to convert subpath to absolute gitignore pattern path
+                    local subPattern = '/' .. relativeToLibPath
+                    libPatterns[nLibPath] = libPatterns[nLibPath] or {}
+                    table.insert(libPatterns[nLibPath], subPattern)
+                end
+            end
+        end
+        if not isLibPattern then
+            pattern[#pattern+1] = path
+        end
     end
 
     local librarys = {}
@@ -239,8 +261,16 @@ function m.getLibraryMatchers(scp)
     local matchers = {}
     for path in pairs(librarys) do
         if fs.exists(fs.path(path)) then
+            local patterns = libPatterns[path]
+            if patterns then
+                -- append default pattern
+                util.arrayMerge(patterns, pattern)
+            else
+                -- use default pattern
+                patterns = pattern
+            end
             local nPath = fs.absolute(fs.path(path)):string()
-            local matcher = glob.gitignore(pattern, {
+            local matcher = glob.gitignore(patterns, {
                 root       = path,
                 ignoreCase = platform.os == 'windows',
             }, globInteferFace)


### PR DESCRIPTION
This adds support for **per library** setting in `ignoreDir` as requested in https://github.com/LuaLS/lua-language-server/discussions/3213.

## Use case

Ignore a same named folder in the library path, but not in current workspace.
For more details please refer to the discussion link above.

## Proposed Solution

After in-depth discussion, we come up with the following approach with **NO** change to existing API while maintaining backward compatibility:

- check if an `ignoreDir` path is a **subpath** of any library path
- if it is a subpath of a library path
  - extract this subpath (which is a relative path to that library path)
  - convert it to **absolute gitignore pattern** by adding a leading `/`
  - keep it as **library specific** ignore pattern
- otherwise treat it as global ignore pattern as before

### Example Config
```jsonc
{
  "workspace.library": [ "/path/to/lib", "/path/to/lib2" ],
  "workspace.ignoreDir": [
    "/path/to/lib/**/lib-ignore", // extracted pattern will be "/**/lib-ignore" and only applies to "/path/to/lib"
    "global-ignore" // this will still apply to all of "/path/to/lib", "/path/to/lib2", current workspace
  ]
}
```

---

## 中文版

支持 `workspace.ignoreDir` 配置 **只應用在指定 library** 的 pattern

### 修改方式
- 對於每1個 `ignoreDir`，檢查是否屬於任意 library 的 **subpath**
- 假設是該 library 下的 subpath
  - 先提取出這個 subpath (就是該 library 下的 1個 relative path)
  - 在最開首補上 `/` 以換成1個 absolute 的 gitignore pattern
  - 並添加到這 library 下的 ignore pattern matcher
- 否則如常當成 global ignore pattern 來添加