### PR TITLE
Made the hardcoded completion field limit configurable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 <!-- Add all new changes here. They will be moved under a version at release -->
-* `NEW` Added `completion.maxFieldCount` which lets you increase the amount of fields to analyze before requiring more specific input
+* `NEW` Added `completion.maxSuggestCount` which lets you increase the amount of fields to analyze before requiring more specific input
 * `New` Omit parameter hints when the argument name matches
 * `FIX` Fix a typo in `no-unknown` diagnostic message
 * `FIX` Autodoc generation so it does not include documentation for builtin Lua language features

--- a/locale/en-us/setting.lua
+++ b/locale/en-us/setting.lua
@@ -178,7 +178,7 @@ config.completion.showWord.Disable       =
 "Do not display context words."
 config.completion.autoRequire            =
 "When the input looks like a file name, automatically `require` this file."
-config.completion.maxFieldCount          =
+config.completion.maxSuggestCount        =
 "Maximum number of fields to analyze for completions. When an object has more fields than this limit, completions will require more specific input to appear."
 config.completion.showParams             =
 "Display parameters in completion list. When the function has multiple definitions, they will be displayed separately."

--- a/script/config/template.lua
+++ b/script/config/template.lua
@@ -347,7 +347,7 @@ local template = {
                                                 'Disable',
                                             },
     ['Lua.completion.autoRequire']          = Type.Boolean >> true,
-    ['Lua.completion.maxFieldCount']        = Type.Integer >> 100,
+    ['Lua.completion.maxSuggestCount']      = Type.Integer >> 100,
     ['Lua.completion.showParams']           = Type.Boolean >> true,
     ['Lua.completion.requireSeparator']     = Type.String  >> '.',
     ['Lua.completion.postfix']              = Type.String  >> '@',

--- a/script/core/completion/completion.lua
+++ b/script/core/completion/completion.lua
@@ -565,9 +565,9 @@ local function checkFieldOfRefs(refs, state, word, startPos, position, parent, o
     local fields = {}
     local funcs  = {}
     local count  = 0
-    local maxFieldCount = config.get(state.uri, 'Lua.completion.maxFieldCount')
+    local maxSuggestCount = config.get(state.uri, 'Lua.completion.maxSuggestCount')
     for _, src in ipairs(refs) do
-        if count > maxFieldCount then
+        if count > maxSuggestCount then
             results.incomplete = true
             break
         end


### PR DESCRIPTION
I'm aware that 4.0.0 is being worked on, couldn't find this exact limit there. Haven't seen public statements or ETAs regarding 4.0.0 either. Don't know whether this change will be applied to the version used in Visual Studio Code but I'm doing this under the assumption that it will considering I found this in the master branch.

Basically, I hit the limit (while doing somewhat reasonable stuff) and I guess this would be a good temp fix. I'm assuming changes to locale/setting.lua and doc/config.md are needed, however I'm not sure what I should've done, make a description and translate to all available languages?